### PR TITLE
[#IOPID-1869] AuthLock service and LockedProfile repo

### DIFF
--- a/apps/session-manager/env.example
+++ b/apps/session-manager/env.example
@@ -44,3 +44,6 @@ ALLOW_ZENDESK_IP_SOURCE_RANGE="::/0"
 
 BPD_BASE_PATH=/bpd/api/v1
 ALLOW_BPD_IP_SOURCE_RANGE="::/0"
+
+LOCKED_PROFILES_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:20003/devstoreaccount1;QueueEndpoint=http://127.0.0.1:20004/devstoreaccount1;TableEndpoint=http://127.0.0.1:20005/devstoreaccount1;
+LOCKED_PROFILES_TABLE_NAME=lockedProfiles

--- a/apps/session-manager/package.json
+++ b/apps/session-manager/package.json
@@ -30,6 +30,7 @@
         "generate:proxy:bpd-models": "shx rm -rf src/generated/bpd && gen-api-models --api-spec api/bpd.yaml --out-dir src/generated/bpd"
     },
     "dependencies": {
+        "@azure/data-tables": "^13.2.2",
         "@azure/storage-queue": "^12.16.0",
         "@pagopa/io-functions-app-sdk": "x",
         "@pagopa/io-functions-commons": "^29.0.4",

--- a/apps/session-manager/src/__mocks__/repositories/table-client-mocks.ts
+++ b/apps/session-manager/src/__mocks__/repositories/table-client-mocks.ts
@@ -1,23 +1,89 @@
-import { TableClient } from "@azure/data-tables";
+import {
+  CreateTableEntityResponse,
+  TableClient,
+  TableTransactionResponse,
+} from "@azure/data-tables";
 import { Mock, vi } from "vitest";
+import { PagedAsyncIterableIterator } from "@azure/data-tables/dist/index";
+import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
+import { NotReleasedAuthenticationLockData } from "../../repositories/locked-profile";
+import { aFiscalCode } from "../user.mocks";
+import { UnlockCode } from "../../generated/fast-login-api/UnlockCode";
 
 export const mockCreateEntity: Mock<
   Parameters<TableClient["createEntity"]>,
   ReturnType<TableClient["createEntity"]>
-> = vi.fn();
+> = vi.fn().mockImplementation(async () => ({}) as CreateTableEntityResponse);
 
 export const mockSubmitTransaction: Mock<
   Parameters<TableClient["submitTransaction"]>,
   ReturnType<TableClient["submitTransaction"]>
-> = vi.fn();
+> = vi
+  .fn()
+  .mockImplementation(
+    async () => ({ status: 202 }) as TableTransactionResponse,
+  );
 
 export const mockListEntities: Mock<
   Parameters<TableClient["listEntities"]>,
   ReturnType<TableClient["listEntities"]>
-> = vi.fn();
+> = vi.fn().mockImplementation(noProfileLockedRecordIterator);
 
 export const mockedTableClient = {
   createEntity: mockCreateEntity,
   submitTransaction: mockSubmitTransaction,
   listEntities: mockListEntities,
 } as unknown as TableClient;
+
+// --------------------------------
+// Data mocks for LockedProfile table storage
+// --------------------------------
+
+export const anUnlockCode = "123456789" as UnlockCode;
+export const anotherUnlockCode = "987654321" as UnlockCode;
+
+export const aNotReleasedData = {
+  partitionKey: aFiscalCode,
+  rowKey: anUnlockCode,
+  CreatedAt: new Date(2022, 1, 1),
+};
+
+export const getLockedProfileIterator = (
+  expectedResults: NotReleasedAuthenticationLockData[],
+) =>
+  (async function* () {
+    for (const data of expectedResults) {
+      yield data;
+    }
+  })() as PagedAsyncIterableIterator<
+    NotReleasedAuthenticationLockData,
+    undefined,
+    undefined
+  >;
+export const profileLockedRecordIterator = async function* () {
+  yield aNotReleasedData;
+} as PagedAsyncIterableIterator<
+  NotReleasedAuthenticationLockData,
+  undefined,
+  undefined
+>;
+export async function* noProfileLockedRecordIterator(): ReturnType<
+  typeof profileLockedRecordIterator
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+> {}
+export async function* errorProfileLockedRecordIterator(): ReturnType<
+  typeof profileLockedRecordIterator
+> {
+  // Sonarcloud requires at least one `yield` before `throw` operation
+  yield aNotReleasedData;
+  throw new Error("an Error");
+}
+export async function* brokeEntityProfileLockedRecordIterator(): ReturnType<
+  typeof profileLockedRecordIterator
+> {
+  // Sonarcloud requires at least one `yield` before `throw` operation
+  yield {
+    ...aNotReleasedData,
+    partitionKey: "CF" as FiscalCode,
+  };
+}

--- a/apps/session-manager/src/__mocks__/repositories/table-client-mocks.ts
+++ b/apps/session-manager/src/__mocks__/repositories/table-client-mocks.ts
@@ -1,0 +1,23 @@
+import { TableClient } from "@azure/data-tables";
+import { Mock, vi } from "vitest";
+
+export const mockCreateEntity: Mock<
+  Parameters<TableClient["createEntity"]>,
+  ReturnType<TableClient["createEntity"]>
+> = vi.fn();
+
+export const mockSubmitTransaction: Mock<
+  Parameters<TableClient["submitTransaction"]>,
+  ReturnType<TableClient["submitTransaction"]>
+> = vi.fn();
+
+export const mockListEntities: Mock<
+  Parameters<TableClient["listEntities"]>,
+  ReturnType<TableClient["listEntities"]>
+> = vi.fn();
+
+export const mockedTableClient = {
+  createEntity: mockCreateEntity,
+  submitTransaction: mockSubmitTransaction,
+  listEntities: mockListEntities,
+} as unknown as TableClient;

--- a/apps/session-manager/src/app.ts
+++ b/apps/session-manager/src/app.ts
@@ -46,14 +46,15 @@ import { withUserFromRequest } from "./utils/user";
 import { AdditionalLoginProps, LoginTypeEnum } from "./types/fast-login";
 import { TimeTracer } from "./utils/timer";
 import { RedisClientMode, RedisClientSelectorType } from "./types/redis";
-import { SpidLogConfig, SpidConfig, ZendeskConfig, BPDConfig } from "./config";
+import {
+  BPDConfig,
+  LollipopConfig,
+  SpidLogConfig,
+  SpidConfig,
+  ZendeskConfig,
+} from "./config";
 import { acsRequestMapper, getLoginTypeOnElegible } from "./utils/fast-login";
 import { LollipopService, RedisSessionStorageService } from "./services";
-import {
-  FF_LOLLIPOP_ENABLED,
-  LOLLIPOP_REVOKE_QUEUE_NAME,
-  LOLLIPOP_REVOKE_STORAGE_CONNECTION_STRING,
-} from "./config/lollipop";
 import { isUserElegibleForFastLogin } from "./config/fast-login";
 import { lollipopLoginMiddleware } from "./utils/lollipop";
 import { checkIP, withIPFromRequest } from "./utils/network";
@@ -92,8 +93,8 @@ export const newApp: (
   );
 
   const lollipopRevokeQueueClient = new QueueClient(
-    LOLLIPOP_REVOKE_STORAGE_CONNECTION_STRING,
-    LOLLIPOP_REVOKE_QUEUE_NAME,
+    LollipopConfig.LOLLIPOP_REVOKE_STORAGE_CONNECTION_STRING,
+    LollipopConfig.LOLLIPOP_REVOKE_QUEUE_NAME,
   );
 
   setupAuthentication(REDIS_CLIENT_SELECTOR);
@@ -277,12 +278,12 @@ export const newApp: (
               getLoginTypeOnElegible(
                 loginType,
                 isUserElegibleForFastLogin(fiscalCode),
-                FF_LOLLIPOP_ENABLED,
+                LollipopConfig.FF_LOLLIPOP_ENABLED,
               ),
           }),
           lollipopMiddleware: toExpressMiddleware(
             lollipopLoginMiddleware(
-              FF_LOLLIPOP_ENABLED,
+              LollipopConfig.FF_LOLLIPOP_ENABLED,
               APIClients.fnLollipopAPIClient,
               appInsightsClient,
             ),

--- a/apps/session-manager/src/config/index.ts
+++ b/apps/session-manager/src/config/index.ts
@@ -7,6 +7,7 @@ import { log } from "../utils/logger";
 import { IoLoginHostUrl } from "../types/common";
 
 import * as BPDConfig from "./bpd";
+import * as LockProfileConfig from "./lock-profile";
 import * as LollipopConfig from "./lollipop";
 import * as SpidConfig from "./spid";
 import * as SpidLogConfig from "./spid-logs";
@@ -25,4 +26,11 @@ export const BACKEND_HOST = pipe(
   }),
 );
 
-export { BPDConfig, LollipopConfig, SpidConfig, SpidLogConfig, ZendeskConfig };
+export {
+  BPDConfig,
+  LockProfileConfig,
+  LollipopConfig,
+  SpidConfig,
+  SpidLogConfig,
+  ZendeskConfig,
+};

--- a/apps/session-manager/src/config/index.ts
+++ b/apps/session-manager/src/config/index.ts
@@ -6,10 +6,11 @@ import { getNodeEnvironmentFromProcessEnv } from "@pagopa/ts-commons/lib/environ
 import { log } from "../utils/logger";
 import { IoLoginHostUrl } from "../types/common";
 
+import * as BPDConfig from "./bpd";
+import * as LollipopConfig from "./lollipop";
 import * as SpidConfig from "./spid";
 import * as SpidLogConfig from "./spid-logs";
 import * as ZendeskConfig from "./zendesk";
-import * as BPDConfig from "./bpd";
 
 export const ENV = getNodeEnvironmentFromProcessEnv(process.env);
 
@@ -24,4 +25,4 @@ export const BACKEND_HOST = pipe(
   }),
 );
 
-export { SpidConfig, SpidLogConfig, ZendeskConfig, BPDConfig };
+export { BPDConfig, LollipopConfig, SpidConfig, SpidLogConfig, ZendeskConfig };

--- a/apps/session-manager/src/config/lock-profile.ts
+++ b/apps/session-manager/src/config/lock-profile.ts
@@ -1,0 +1,9 @@
+import { getRequiredENVVar } from "../utils/environment";
+
+// Needed to verify if a profile has been locked
+export const LOCKED_PROFILES_STORAGE_CONNECTION_STRING = getRequiredENVVar(
+  "LOCKED_PROFILES_STORAGE_CONNECTION_STRING",
+);
+export const LOCKED_PROFILES_TABLE_NAME = getRequiredENVVar(
+  "LOCKED_PROFILES_TABLE_NAME",
+);

--- a/apps/session-manager/src/controllers/fast-login.ts
+++ b/apps/session-manager/src/controllers/fast-login.ts
@@ -19,7 +19,6 @@ import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { safeXMLParseFromString } from "@pagopa/io-spid-commons/dist/utils/samlUtils";
 import { GenerateNonceResponse } from "../generated/fast-login-api/GenerateNonceResponse";
 import { assertNever, readableProblem } from "../utils/errors";
-import { getFnFastLoginAPIClient } from "../repositories/fast-login-api";
 import {
   BPDToken,
   FIMSToken,
@@ -41,6 +40,7 @@ import { RedisClientSelectorType } from "../types/redis";
 import { RedisRepositoryDeps } from "../repositories/redis";
 import { WithIP } from "../utils/network";
 import { isUserElegibleForFastLogin } from "../config/fast-login";
+import { FnFastLoginRepo } from "../repositories";
 import { SESSION_ID_LENGTH_BYTES, SESSION_TOKEN_LENGTH_BYTES } from "./session";
 
 const generateSessionTokens = (
@@ -124,9 +124,7 @@ const callLcSetSession = (): TE.TaskEither<IResponseErrorInternal, true> =>
 // Endpoints
 //
 export const generateNonceEndpoint: RTE.ReaderTaskEither<
-  {
-    fnFastLoginAPIClient: ReturnType<getFnFastLoginAPIClient>;
-  },
+  FnFastLoginRepo.FnFastLoginRepositoryDeps,
   Error,
   IResponseSuccessJson<GenerateNonceResponse>
 > = ({ fnFastLoginAPIClient }) =>
@@ -160,7 +158,7 @@ export const generateNonceEndpoint: RTE.ReaderTaskEither<
   );
 
 type FastLoginDeps<T extends ResLocals> = {
-  fnFastLoginAPIClient: ReturnType<getFnFastLoginAPIClient>;
+  fnFastLoginAPIClient: ReturnType<FnFastLoginRepo.FnFastLoginAPIClient>;
   sessionTTL: number;
   locals?: T;
 } & WithIP;

--- a/apps/session-manager/src/controllers/fast-login.ts
+++ b/apps/session-manager/src/controllers/fast-login.ts
@@ -157,11 +157,11 @@ export const generateNonceEndpoint: RTE.ReaderTaskEither<
     }),
   );
 
-type FastLoginDeps<T extends ResLocals> = {
-  fnFastLoginAPIClient: ReturnType<FnFastLoginRepo.FnFastLoginAPIClient>;
-  sessionTTL: number;
-  locals?: T;
-} & WithIP;
+type FastLoginDeps<T extends ResLocals> =
+  FnFastLoginRepo.FnFastLoginRepositoryDeps & {
+    sessionTTL: number;
+    locals?: T;
+  } & WithIP;
 
 type FastLoginHandler = <T extends ResLocals>(
   deps: RedisRepositoryDeps & FastLoginDeps<T>,

--- a/apps/session-manager/src/repositories/__tests__/locked-profile.spec.ts
+++ b/apps/session-manager/src/repositories/__tests__/locked-profile.spec.ts
@@ -1,0 +1,191 @@
+import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+import * as E from "fp-ts/Either";
+import { RestError } from "@azure/data-tables";
+import { aFiscalCode } from "../../__mocks__/user.mocks";
+import {
+  getUserAuthenticationLocks,
+  lockUserAuthentication,
+  unlockUserAuthentication,
+} from "../locked-profile";
+import {
+  aNotReleasedData,
+  anUnlockCode,
+  anotherUnlockCode,
+  brokeEntityProfileLockedRecordIterator,
+  errorProfileLockedRecordIterator,
+  getLockedProfileIterator,
+  mockCreateEntity,
+  mockListEntities,
+  mockSubmitTransaction,
+  mockedTableClient,
+} from "../../__mocks__/repositories/table-client-mocks";
+
+describe("LockProfileRepo#lockUserAuthentication", () => {
+  beforeAll(() => {
+    vi.useFakeTimers({ now: new Date(2020, 3, 1) });
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  test("should return true if CF-unlockcode has been stored sucessfully in table storage", async () => {
+    const result = await lockUserAuthentication(
+      aFiscalCode,
+      anUnlockCode,
+    )({ lockUserTableClient: mockedTableClient })();
+
+    expect(result).toEqual(E.right(true));
+    expect(mockCreateEntity).toHaveBeenCalledWith({
+      partitionKey: aFiscalCode,
+      rowKey: anUnlockCode,
+      CreatedAt: new Date(2020, 3, 1),
+    });
+  });
+
+  test("should return an Error when CF-unlockcode has already been stored in table storage", async () => {
+    mockCreateEntity.mockRejectedValueOnce(
+      new RestError("Conflict", { statusCode: 409 }),
+    );
+    const result = await lockUserAuthentication(
+      aFiscalCode,
+      anUnlockCode,
+    )({ lockUserTableClient: mockedTableClient })();
+
+    expect(result).toEqual(
+      E.left(new Error("Something went wrong creating the record")),
+    );
+  });
+
+  test("should return an Error when an error occurred while storing value in table storage", async () => {
+    mockCreateEntity.mockRejectedValueOnce(
+      new RestError("Another Error", { statusCode: 418 }),
+    );
+    const result = await lockUserAuthentication(
+      aFiscalCode,
+      anUnlockCode,
+    )({ lockUserTableClient: mockedTableClient })();
+
+    expect(result).toEqual(
+      E.left(new Error("Something went wrong creating the record")),
+    );
+  });
+});
+
+describe("LockProfileRepo#unlockUserAuthentication", () => {
+  test("should return true when records update transaction succeded", async () => {
+    const result = await unlockUserAuthentication(aFiscalCode, [
+      anUnlockCode,
+      anotherUnlockCode,
+    ])({ lockUserTableClient: mockedTableClient })();
+
+    expect(result).toEqual(E.right(true));
+    expect(mockSubmitTransaction).toHaveBeenCalledWith([
+      [
+        "update",
+        {
+          partitionKey: aFiscalCode,
+          rowKey: anUnlockCode,
+          Released: true,
+        },
+      ],
+      [
+        "update",
+        {
+          partitionKey: aFiscalCode,
+          rowKey: anotherUnlockCode,
+          Released: true,
+        },
+      ],
+    ]);
+  });
+
+  test("should return an Error when at least one CF-unlock code was not found", async () => {
+    mockSubmitTransaction.mockRejectedValueOnce(
+      new RestError("Not Found", { statusCode: 404 }),
+    );
+    const result = await unlockUserAuthentication(aFiscalCode, [
+      anUnlockCode,
+      anotherUnlockCode,
+    ])({ lockUserTableClient: mockedTableClient })();
+
+    expect(result).toEqual(
+      E.left(new Error("Something went wrong updating the record")),
+    );
+  });
+
+  test("should return an Error when an error occurred updating the record", async () => {
+    mockSubmitTransaction.mockRejectedValueOnce(
+      new RestError("An Error", { statusCode: 500 }),
+    );
+    const result = await unlockUserAuthentication(aFiscalCode, [anUnlockCode])({
+      lockUserTableClient: mockedTableClient,
+    })();
+
+    expect(result).toEqual(
+      E.left(new Error("Something went wrong updating the record")),
+    );
+  });
+});
+
+describe("AuthenticationLockService#getUserAuthenticationLocks", () => {
+  test("should return an empty array if query returns no records from table storage", async () => {
+    const result = await getUserAuthenticationLocks(aFiscalCode)({
+      lockUserTableClient: mockedTableClient,
+    })();
+
+    expect(result).toEqual(E.right([]));
+    expect(mockListEntities).toHaveBeenCalledWith({
+      queryOptions: {
+        filter: `PartitionKey eq '${aFiscalCode}' and not Released`,
+      },
+    });
+  });
+
+  test.each`
+    title             | records
+    ${"one record"}   | ${[aNotReleasedData]}
+    ${"more records"} | ${[aNotReleasedData, { ...aNotReleasedData, rowKey: anotherUnlockCode }]}
+  `(
+    "should return all the records, if $title not Released are found in table storage",
+    async ({ records }) => {
+      mockListEntities.mockImplementationOnce(() =>
+        getLockedProfileIterator(records),
+      );
+
+      const result = await getUserAuthenticationLocks(aFiscalCode)({
+        lockUserTableClient: mockedTableClient,
+      })();
+
+      expect(result).toEqual(E.right(records));
+    },
+  );
+
+  test("should return an error if something went wrong retrieving the records", async () => {
+    mockListEntities.mockImplementationOnce(errorProfileLockedRecordIterator);
+
+    const result = await getUserAuthenticationLocks(aFiscalCode)({
+      lockUserTableClient: mockedTableClient,
+    })();
+
+    expect(result).toEqual(E.left(Error("an Error")));
+  });
+
+  test("should return an error if something went wrong decoding a record", async () => {
+    mockListEntities.mockImplementationOnce(
+      brokeEntityProfileLockedRecordIterator,
+    );
+
+    const result = await getUserAuthenticationLocks(aFiscalCode)({
+      lockUserTableClient: mockedTableClient,
+    })();
+
+    expect(result).toEqual(
+      E.left(
+        Error(
+          'value ["CF"] at [root.0.partitionKey] is not a valid [string that matches the pattern "^[A-Z]{6}[0-9LMNPQRSTUV]{2}[ABCDEHLMPRST][0-9LMNPQRSTUV]{2}[A-Z][0-9LMNPQRSTUV]{3}[A-Z]$"]',
+        ),
+      ),
+    );
+  });
+});

--- a/apps/session-manager/src/repositories/fast-login-api.ts
+++ b/apps/session-manager/src/repositories/fast-login-api.ts
@@ -20,4 +20,8 @@ export function getFnFastLoginAPIClient(
   });
 }
 
-export type getFnFastLoginAPIClient = typeof getFnFastLoginAPIClient;
+export type FnFastLoginAPIClient = typeof getFnFastLoginAPIClient;
+
+export type FnFastLoginRepositoryDeps = {
+  fnFastLoginAPIClient: ReturnType<FnFastLoginAPIClient>;
+};

--- a/apps/session-manager/src/repositories/index.ts
+++ b/apps/session-manager/src/repositories/index.ts
@@ -1,14 +1,18 @@
 import * as FnAppRepo from "./fn-app-api";
-import * as RedisRepo from "./redis";
+import * as FnFastLoginRepo from "./fast-login-api";
 import * as FnLollipopRepo from "./lollipop-api";
+import * as RedisRepo from "./redis";
 import * as SpidLogsRepo from "./spid-logs";
+import * as LockedProfileRepo from "./locked-profile";
 import * as LollipopRevokeRepo from "./lollipop-revoke-queue";
 import * as NotificationsRepo from "./notifications";
 
 export {
   FnAppRepo,
   FnLollipopRepo,
+  FnFastLoginRepo,
   RedisRepo,
+  LockedProfileRepo,
   LollipopRevokeRepo,
   NotificationsRepo,
   SpidLogsRepo,

--- a/apps/session-manager/src/repositories/locked-profile.ts
+++ b/apps/session-manager/src/repositories/locked-profile.ts
@@ -1,0 +1,97 @@
+import * as RTE from "fp-ts/ReaderTaskEither";
+import { TableClient, TransactionAction, odata } from "@azure/data-tables";
+import { flow, identity, pipe } from "fp-ts/lib/function";
+import * as TE from "fp-ts/TaskEither";
+import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
+import * as E from "fp-ts/lib/Either";
+import * as ROA from "fp-ts/ReadonlyArray";
+import { DateFromString } from "@pagopa/ts-commons/lib/dates";
+import * as t from "io-ts";
+import * as AI from "@pagopa/io-functions-commons/dist/src/utils/async_iterable_task";
+import { errorsToError } from "../utils/errors";
+import { UnlockCode } from "../generated/fast-login-api/UnlockCode";
+
+export type LockUserAuthenticationDeps = {
+  lockUserTableClient: TableClient;
+};
+
+export type NotReleasedAuthenticationLockData = t.TypeOf<
+  typeof NotReleasedAuthenticationLockData
+>;
+const NotReleasedAuthenticationLockData = t.type({
+  partitionKey: FiscalCode,
+  rowKey: UnlockCode,
+  CreatedAt: DateFromString,
+});
+
+export const lockUserAuthentication: (
+  fiscalCode: FiscalCode,
+  unlockCode: UnlockCode,
+) => RTE.ReaderTaskEither<LockUserAuthenticationDeps, Error, true> =
+  (fiscalCode, unlockCode) => (deps) =>
+    pipe(
+      TE.tryCatch(
+        () =>
+          deps.lockUserTableClient.createEntity({
+            partitionKey: fiscalCode,
+            rowKey: unlockCode,
+            CreatedAt: new Date(),
+          }),
+        (_) => new Error("Something went wrong creating the record"),
+      ),
+      TE.map((_) => true as const),
+    );
+
+export const unlockUserAuthentication: (
+  fiscalCode: FiscalCode,
+  unlockCodes: ReadonlyArray<UnlockCode>,
+) => RTE.ReaderTaskEither<LockUserAuthenticationDeps, Error, true> =
+  (fiscalCode, unlockCodes) => (deps) =>
+    pipe(
+      unlockCodes,
+      ROA.map(
+        (unlockCode) =>
+          [
+            "update",
+            {
+              partitionKey: fiscalCode,
+              rowKey: unlockCode,
+              Released: true,
+            },
+          ] as TransactionAction,
+      ),
+      (actions) =>
+        TE.tryCatch(
+          () => deps.lockUserTableClient.submitTransaction(Array.from(actions)),
+          identity,
+        ),
+      TE.filterOrElseW(
+        (response) => response.status === 202,
+        () => void 0,
+      ),
+      TE.mapLeft(() => new Error("Something went wrong updating the record")),
+      TE.map(() => true as const),
+    );
+
+export const getUserAuthenticationLocks: (
+  fiscalCode: FiscalCode,
+) => RTE.ReaderTaskEither<
+  LockUserAuthenticationDeps,
+  Error,
+  ReadonlyArray<NotReleasedAuthenticationLockData>
+> = (fiscalCode) => (deps) =>
+  pipe(
+    deps.lockUserTableClient.listEntities({
+      queryOptions: {
+        filter: odata`PartitionKey eq ${fiscalCode} and not Released`,
+      },
+    }),
+    AI.fromAsyncIterable,
+    AI.foldTaskEither(E.toError),
+    TE.chainEitherK(
+      flow(
+        t.array(NotReleasedAuthenticationLockData).decode,
+        E.mapLeft(errorsToError),
+      ),
+    ),
+  );

--- a/apps/session-manager/src/repositories/lollipop-api.ts
+++ b/apps/session-manager/src/repositories/lollipop-api.ts
@@ -23,5 +23,5 @@ export function getLollipopApiClient(
 export type LollipopApiClient = ReturnType<typeof getLollipopApiClient>;
 
 export type LollipopApiDeps = {
-  lollipopApiClient: LollipopApiClient;
+  fnLollipopAPIClient: LollipopApiClient;
 };

--- a/apps/session-manager/src/services/__tests__/authentication-lock.spec.ts
+++ b/apps/session-manager/src/services/__tests__/authentication-lock.spec.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect, vi, afterEach } from "vitest";
+import { PagedAsyncIterableIterator } from "@azure/data-tables/dist/index";
+import { pipe } from "fp-ts/lib/function";
+import * as E from "fp-ts/Either";
+import { TableEntityResultPage } from "@azure/data-tables";
+import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
+import {
+  mockListEntities,
+  mockedTableClient,
+} from "../../__mocks__/repositories/table-client-mocks";
+import { aFiscalCode } from "../../__mocks__/user.mocks";
+import { NotReleasedAuthenticationLockData } from "../../repositories/locked-profile";
+import { isUserAuthenticationLocked } from "../authentication-lock";
+import { UnlockCode } from "../../generated/fast-login-api/UnlockCode";
+
+describe("AuthLockService#isUserAuthenticationLocked", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const mockedDependencies = { lockUserTableClient: mockedTableClient };
+  const getIterator = (expectedResults: NotReleasedAuthenticationLockData[]) =>
+    (async function* () {
+      for (const data of expectedResults) {
+        yield data;
+      }
+    })() as PagedAsyncIterableIterator<
+      NotReleasedAuthenticationLockData,
+      undefined,
+      undefined
+    >;
+
+  test("should return true if the user has active locks", async () => {
+    const expectedResults = [
+      {
+        etag: "a",
+        partitionKey: aFiscalCode,
+        rowKey: "001122330" as UnlockCode,
+        CreatedAt: new Date().toISOString() as unknown as Date,
+      },
+      {
+        etag: "a",
+        partitionKey: aFiscalCode,
+        rowKey: "001122999" as UnlockCode,
+        CreatedAt: new Date().toISOString() as unknown as Date,
+      },
+    ] as TableEntityResultPage<NotReleasedAuthenticationLockData>;
+    mockListEntities.mockImplementation(() => getIterator(expectedResults));
+
+    const result = await pipe(
+      mockedDependencies,
+      isUserAuthenticationLocked(aFiscalCode),
+    )();
+
+    expect(mockListEntities).toBeCalled();
+    expect(result).toEqual(E.right(true));
+  });
+
+  test("should return false if the user don't has active locks", async () => {
+    mockListEntities.mockImplementation(() => getIterator([]));
+
+    const result = await pipe(
+      mockedDependencies,
+      isUserAuthenticationLocked(aFiscalCode),
+    )();
+
+    expect(mockListEntities).toBeCalled();
+    expect(result).toEqual(E.right(false));
+  });
+
+  test("should return an error if a decode error occurs reading from the storage", async () => {
+    mockListEntities.mockImplementation(() =>
+      getIterator([
+        {
+          partitionKey: "anInvalidFiscalCode" as FiscalCode,
+          rowKey: "001122330" as UnlockCode,
+          CreatedAt: new Date().toISOString() as unknown as Date,
+        },
+      ]),
+    );
+
+    const result = await pipe(
+      mockedDependencies,
+      isUserAuthenticationLocked(aFiscalCode),
+    )();
+
+    expect(mockListEntities).toBeCalled();
+    expect(E.isLeft(result)).toBeTruthy();
+  });
+});

--- a/apps/session-manager/src/services/__tests__/lollipop.spec.ts
+++ b/apps/session-manager/src/services/__tests__/lollipop.spec.ts
@@ -48,7 +48,7 @@ describe("LollipopService#generateLCParams", () => {
     vi.clearAllMocks();
   });
 
-  const mockedDependencies = { lollipopApiClient: mockedLollipopApiClient };
+  const mockedDependencies = { fnLollipopAPIClient: mockedLollipopApiClient };
 
   test("should return an LCParam object, when all dependencies are ok", async () => {
     const result = await pipe(

--- a/apps/session-manager/src/services/authentication-lock.ts
+++ b/apps/session-manager/src/services/authentication-lock.ts
@@ -1,6 +1,6 @@
 import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
 import * as RTE from "fp-ts/ReaderTaskEither";
-import { pipe } from "fp-ts/lib/function";
+import { flow } from "fp-ts/lib/function";
 import * as TE from "fp-ts/TaskEither";
 import * as ROA from "fp-ts/ReadonlyArray";
 import { LockedProfileRepo } from "../repositories";
@@ -10,10 +10,8 @@ type AuthLockServiceDeps = LockUserAuthenticationDeps;
 
 export const isUserAuthenticationLocked: (
   fiscalCode: FiscalCode,
-) => RTE.ReaderTaskEither<AuthLockServiceDeps, Error, boolean> =
-  (fiscalCode) => (deps) =>
-    pipe(
-      deps,
-      LockedProfileRepo.getUserAuthenticationLocks(fiscalCode),
-      TE.map(ROA.isNonEmpty),
-    );
+) => RTE.ReaderTaskEither<AuthLockServiceDeps, Error, boolean> = (fiscalCode) =>
+  flow(
+    LockedProfileRepo.getUserAuthenticationLocks(fiscalCode),
+    TE.map(ROA.isNonEmpty),
+  );

--- a/apps/session-manager/src/services/authentication-lock.ts
+++ b/apps/session-manager/src/services/authentication-lock.ts
@@ -4,9 +4,8 @@ import { flow } from "fp-ts/lib/function";
 import * as TE from "fp-ts/TaskEither";
 import * as ROA from "fp-ts/ReadonlyArray";
 import { LockedProfileRepo } from "../repositories";
-import { LockUserAuthenticationDeps } from "../repositories/locked-profile";
 
-type AuthLockServiceDeps = LockUserAuthenticationDeps;
+type AuthLockServiceDeps = LockedProfileRepo.LockUserAuthenticationDeps;
 
 export const isUserAuthenticationLocked: (
   fiscalCode: FiscalCode,

--- a/apps/session-manager/src/services/authentication-lock.ts
+++ b/apps/session-manager/src/services/authentication-lock.ts
@@ -1,0 +1,19 @@
+import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
+import * as RTE from "fp-ts/ReaderTaskEither";
+import { pipe } from "fp-ts/lib/function";
+import * as TE from "fp-ts/TaskEither";
+import * as ROA from "fp-ts/ReadonlyArray";
+import { LockedProfileRepo } from "../repositories";
+import { LockUserAuthenticationDeps } from "../repositories/locked-profile";
+
+type AuthLockServiceDeps = LockUserAuthenticationDeps;
+
+export const isUserAuthenticationLocked: (
+  fiscalCode: FiscalCode,
+) => RTE.ReaderTaskEither<AuthLockServiceDeps, Error, boolean> =
+  (fiscalCode) => (deps) =>
+    pipe(
+      deps,
+      LockedProfileRepo.getUserAuthenticationLocks(fiscalCode),
+      TE.map(ROA.isNonEmpty),
+    );

--- a/apps/session-manager/src/services/lollipop.ts
+++ b/apps/session-manager/src/services/lollipop.ts
@@ -40,11 +40,11 @@ export const generateLCParams: (
   LcParams
 > =
   (assertionRef, operationId) =>
-  ({ lollipopApiClient }) =>
+  ({ fnLollipopAPIClient }) =>
     pipe(
       TE.tryCatch(
         () =>
-          lollipopApiClient.generateLCParams({
+          fnLollipopAPIClient.generateLCParams({
             assertion_ref: assertionRef,
             body: {
               operation_id: operationId,

--- a/apps/session-manager/src/services/redis-session-storage.ts
+++ b/apps/session-manager/src/services/redis-session-storage.ts
@@ -335,11 +335,7 @@ export const getByZendeskToken: (
   pipe(
     loadSessionByToken(RedisRepo.zendeskTokenPrefix, token),
     RTE.map(O.some),
-    RTE.orElse((err) =>
-      err === RedisRepo.sessionNotFoundError
-        ? RTE.right(O.none)
-        : RTE.left(err),
-    ),
+    RTE.orElseW(noneOrErrorWhenNotFound),
   );
 
 /**

--- a/apps/session-manager/src/services/redis-session-storage.ts
+++ b/apps/session-manager/src/services/redis-session-storage.ts
@@ -295,6 +295,13 @@ const getUserTokens = (
   },
 });
 
+const noneOrErrorWhenNotFound: <T>(
+  error: Error,
+) => RTE.ReaderTaskEither<T, Error, O.Option<never>> = (error) =>
+  error === RedisRepo.sessionNotFoundError
+    ? RTE.right(O.none)
+    : RTE.left(error);
+
 /**
  * Retrieves a value from the cache using the FIMS token.
  * @param token the fims token
@@ -310,11 +317,7 @@ export const getByFIMSToken: (
   pipe(
     loadSessionByToken(RedisRepo.fimsTokenPrefix, token),
     RTE.map(O.some),
-    RTE.orElseW((error) =>
-      error === RedisRepo.sessionNotFoundError
-        ? RTE.right(O.none)
-        : RTE.left(error),
-    ),
+    RTE.orElseW(noneOrErrorWhenNotFound),
   );
 
 /**
@@ -354,11 +357,7 @@ export const getByBPDToken: (
   pipe(
     loadSessionByToken(RedisRepo.bpdTokenPrefix, token),
     RTE.map(O.some),
-    RTE.orElse((error) =>
-      error === RedisRepo.sessionNotFoundError
-        ? RTE.right(O.none)
-        : RTE.left(error),
-    ),
+    RTE.orElseW(noneOrErrorWhenNotFound),
   );
 
 // ---------------------------------

--- a/apps/session-manager/src/utils/__tests__/lollipop.spec.ts
+++ b/apps/session-manager/src/utils/__tests__/lollipop.spec.ts
@@ -101,7 +101,7 @@ describe("extractLollipopLocalsFromLollipopHeaders|>missing fiscal code", () => 
         undefined,
       )({
         redisClientSelector: mockRedisClientSelector,
-        lollipopApiClient: mockLollipopClient,
+        fnLollipopAPIClient: mockLollipopClient,
       })();
 
       expect(mockGenerateLCParams).toHaveBeenCalledTimes(generateLCParamsCalls);
@@ -126,7 +126,7 @@ describe("extractLollipopLocalsFromLollipopHeaders|>missing fiscal code", () => 
       undefined,
     )({
       redisClientSelector: mockRedisClientSelector,
-      lollipopApiClient: mockLollipopClient,
+      fnLollipopAPIClient: mockLollipopClient,
     })();
 
     expect(mockGenerateLCParams).toHaveBeenCalledTimes(3);

--- a/apps/session-manager/src/utils/api-clients.ts
+++ b/apps/session-manager/src/utils/api-clients.ts
@@ -1,8 +1,4 @@
-import {
-  LOLLIPOP_API_KEY,
-  LOLLIPOP_API_URL,
-  LOLLIPOP_API_BASE_PATH,
-} from "../config/lollipop";
+import { LollipopConfig } from "../config/index";
 import { FnAppRepo, FnFastLoginRepo, FnLollipopRepo } from "../repositories";
 import { getRequiredENVVar } from "./environment";
 import { httpOrHttpsApiFetch } from "./fetch";
@@ -21,9 +17,9 @@ export const initAPIClientsDependencies: () => FnAppRepo.FnAppAPIRepositoryDeps 
     getRequiredENVVar("FAST_LOGIN_API_URL"),
   );
   const fnLollipopAPIClient = FnLollipopRepo.getLollipopApiClient(
-    LOLLIPOP_API_KEY,
-    LOLLIPOP_API_URL,
-    LOLLIPOP_API_BASE_PATH,
+    LollipopConfig.LOLLIPOP_API_KEY,
+    LollipopConfig.LOLLIPOP_API_URL,
+    LollipopConfig.LOLLIPOP_API_BASE_PATH,
     httpOrHttpsApiFetch,
   );
 

--- a/apps/session-manager/src/utils/api-clients.ts
+++ b/apps/session-manager/src/utils/api-clients.ts
@@ -1,0 +1,35 @@
+import {
+  LOLLIPOP_API_KEY,
+  LOLLIPOP_API_URL,
+  LOLLIPOP_API_BASE_PATH,
+} from "../config/lollipop";
+import { FnAppRepo, FnFastLoginRepo, FnLollipopRepo } from "../repositories";
+import { getRequiredENVVar } from "./environment";
+import { httpOrHttpsApiFetch } from "./fetch";
+
+export const initAPIClientsDependencies: () => FnAppRepo.FnAppAPIRepositoryDeps &
+  FnFastLoginRepo.FnFastLoginRepositoryDeps &
+  FnLollipopRepo.LollipopApiDeps = () => {
+  // Create the API client for the Azure Functions App
+  const fnAppAPIClient = FnAppRepo.FnAppAPIClient(
+    getRequiredENVVar("API_URL"),
+    getRequiredENVVar("API_KEY"),
+    httpOrHttpsApiFetch,
+  );
+  const fnFastLoginAPIClient = FnFastLoginRepo.getFnFastLoginAPIClient(
+    getRequiredENVVar("FAST_LOGIN_API_KEY"),
+    getRequiredENVVar("FAST_LOGIN_API_URL"),
+  );
+  const fnLollipopAPIClient = FnLollipopRepo.getLollipopApiClient(
+    LOLLIPOP_API_KEY,
+    LOLLIPOP_API_URL,
+    LOLLIPOP_API_BASE_PATH,
+    httpOrHttpsApiFetch,
+  );
+
+  return {
+    fnAppAPIClient,
+    fnFastLoginAPIClient,
+    fnLollipopAPIClient,
+  };
+};

--- a/docker/session-manager/env-dev
+++ b/docker/session-manager/env-dev
@@ -47,3 +47,6 @@ ALLOW_ZENDESK_IP_SOURCE_RANGE="::/0"
 
 BPD_BASE_PATH=/bpd/api/v1
 ALLOW_BPD_IP_SOURCE_RANGE="::/0"
+
+LOCKED_PROFILES_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:20003/devstoreaccount1;QueueEndpoint=http://127.0.0.1:20004/devstoreaccount1;TableEndpoint=http://127.0.0.1:20005/devstoreaccount1;
+LOCKED_PROFILES_TABLE_NAME=lockedProfiles

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,6 +1206,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pagopa/io-session-manager@workspace:apps/session-manager"
   dependencies:
+    "@azure/data-tables": "npm:^13.2.2"
     "@azure/storage-queue": "npm:^12.16.0"
     "@pagopa/eslint-config": "npm:^3.0.0"
     "@pagopa/io-functions-app-sdk": "npm:x"


### PR DESCRIPTION
⚠️ Depends on https://github.com/pagopa/io-infra/pull/998
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Porting `AuthenticationLock` service
Porting `LockedProfile` repo
add config for locked profile
add some utils for app initialization

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Some part of the bigger porting for the `acs` endpoint are in this PR

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test for the `AuthLockService` and `getUserAuthenticationLocks` in `LockedProfileRepo`
Unit test for the other methods into the Repo will be added on other PR that will use the untested utils.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

