### PR TITLE
[#IOPID-1901] HTTP Graceful Shutdown

### DIFF
--- a/apps/session-manager/env.example
+++ b/apps/session-manager/env.example
@@ -1,7 +1,7 @@
 ################
 # AppInsinghts #
 ################
-#APPINSIGHTS_CONNECTION_STRING=""
+APPINSIGHTS_CONNECTION_STRING=InstrumentationKey=foo;IngestionEndpoint=http://localhost;LiveEndpoint=http://localhost
 APPINSIGHTS_DISABLED=false
 APPINSIGHTS_SAMPLING_PERCENTAGE=100
 # cloud_RoleName value; if undefined, WEBSITE_SITE_NAME will be used

--- a/apps/session-manager/env.example
+++ b/apps/session-manager/env.example
@@ -1,7 +1,7 @@
 ################
 # AppInsinghts #
 ################
-APPINSIGHTS_CONNECTION_STRING=""
+#APPINSIGHTS_CONNECTION_STRING=""
 APPINSIGHTS_DISABLED=false
 APPINSIGHTS_SAMPLING_PERCENTAGE=100
 # cloud_RoleName value; if undefined, WEBSITE_SITE_NAME will be used

--- a/apps/session-manager/package.json
+++ b/apps/session-manager/package.json
@@ -44,6 +44,7 @@
         "express": "^4.19.2",
         "fp-ts": "^2.16.5",
         "helmet": "^7.1.0",
+        "http-graceful-shutdown": "^3.1.13",
         "io-ts": "^2.2.21",
         "io-ts-types": "^0.5.16",
         "jose": "^5.3.0",

--- a/apps/session-manager/src/__tests__/app.spec.ts
+++ b/apps/session-manager/src/__tests__/app.spec.ts
@@ -1,29 +1,30 @@
-import { describe, test, vi, expect, afterAll, beforeEach } from "vitest";
+import { describe, test, vi, afterAll } from "vitest";
 import request from "supertest";
 import { RedisRepo } from "../repositories";
-import {
-  mockQuit,
-  mockRedisClientSelector,
-  mockSelect,
-} from "../__mocks__/redis.mocks";
+import { mockRedisClientSelector } from "../__mocks__/redis.mocks";
 
 vi.stubEnv(
   "IDP_METADATA_URL",
   "https://api.is.eng.pagopa.it/idp-keys/spid/latest",
 );
 
-import { newApp } from "../app";
-import { getCurrentBackendVersion } from "../utils/package";
-
 vi.spyOn(RedisRepo, "RedisClientSelector").mockImplementation(
   () => async () => mockRedisClientSelector,
 );
 
+import { newApp } from "../app";
+import { getCurrentBackendVersion } from "../utils/package";
+// import { serverApp } from "../server";
+
 const X_FORWARDED_PROTO_HEADER = "X-Forwarded-Proto";
 const STOP_EVENT_NAME = "server:stop";
 
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
 describe("Test redirect to HTTPS", async () => {
-  const app = await newApp({});
+  const { app } = await newApp({});
 
   afterAll(() => {
     app.emit(STOP_EVENT_NAME);
@@ -41,20 +42,5 @@ describe("Test redirect to HTTPS", async () => {
       .get("/healthcheck")
       .set(X_FORWARDED_PROTO_HEADER, "https")
       .expect(200);
-  });
-});
-
-describe("Graceful Shutdown", async () => {
-  const app = await newApp({});
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  afterAll(() => {
-    app.emit(STOP_EVENT_NAME);
-  });
-  test("should call quit method for each redis when the server stops", async () => {
-    app.emit(STOP_EVENT_NAME);
-    expect(mockQuit).toBeCalledTimes(mockSelect().length);
   });
 });

--- a/apps/session-manager/src/__tests__/app.spec.ts
+++ b/apps/session-manager/src/__tests__/app.spec.ts
@@ -14,7 +14,6 @@ vi.spyOn(RedisRepo, "RedisClientSelector").mockImplementation(
 
 import { newApp } from "../app";
 import { getCurrentBackendVersion } from "../utils/package";
-// import { serverApp } from "../server";
 
 const X_FORWARDED_PROTO_HEADER = "X-Forwarded-Proto";
 const STOP_EVENT_NAME = "server:stop";

--- a/apps/session-manager/src/__tests__/server.spec.ts
+++ b/apps/session-manager/src/__tests__/server.spec.ts
@@ -1,0 +1,49 @@
+import { Server } from "http";
+import { afterAll, describe, expect, test, vi } from "vitest";
+import express from "express";
+import {
+  mockQuit,
+  mockRedisClientSelector,
+  mockSelect,
+} from "../__mocks__/redis.mocks";
+
+vi.mock("../repositories/redis", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../repositories/redis")>()),
+  // this will only affect "foo" outside of the original module
+  RedisClientSelector: () => async () => mockRedisClientSelector,
+}));
+vi.mock("http-graceful-shutdown");
+
+import { serverStarter } from "../server";
+import { newApp } from "../app";
+
+const STOP_EVENT_NAME = "server:stop";
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+const mockListen = vi
+  .fn<
+    Parameters<express.Application["listen"]>,
+    ReturnType<express.Application["listen"]>
+  >()
+  .mockImplementation(() => ({}) as unknown as Server);
+
+describe("Graceful Shutdown", async () => {
+  test("should call quit method for each redis when the server stops", async () => {
+    const appAndParams = await newApp({});
+    await serverStarter(
+      Promise.resolve({
+        ...appAndParams,
+        app: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ...(appAndParams.app as any),
+          listen: mockListen,
+        },
+      }),
+    );
+    appAndParams.app.emit(STOP_EVENT_NAME);
+    expect(mockQuit).toBeCalledTimes(mockSelect().length);
+  });
+});

--- a/apps/session-manager/src/config/server.ts
+++ b/apps/session-manager/src/config/server.ts
@@ -1,0 +1,14 @@
+/* eslint-disable turbo/no-undeclared-env-vars */
+export const PORT = process.env.WEBSITES_PORT ?? 3000;
+
+// Set default for graceful-shutdown
+const DEFAULT_SHUTDOWN_SIGNALS = "SIGINT SIGTERM";
+const DEFAULT_SHUTDOWN_TIMEOUT_MILLIS = 30000;
+
+export const SHUTDOWN_SIGNALS: string =
+  process.env.SHUTDOWN_SIGNALS || DEFAULT_SHUTDOWN_SIGNALS;
+
+export const SHUTDOWN_TIMEOUT_MILLIS: number = process.env
+  .DEFAULT_SHUTDOWN_TIMEOUT_MILLIS
+  ? parseInt(process.env.DEFAULT_SHUTDOWN_TIMEOUT_MILLIS, 10)
+  : DEFAULT_SHUTDOWN_TIMEOUT_MILLIS;

--- a/apps/session-manager/src/controllers/__tests__/session.spec.ts
+++ b/apps/session-manager/src/controllers/__tests__/session.spec.ts
@@ -169,6 +169,7 @@ describe("logout", () => {
     // Repositories are not used, since we mocked the service layer
     lollipopApiClient: {} as LollipopApiClient,
     redisClientSelector: {} as RedisClientSelectorType,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     lollipopRevokeQueueClient: {} as any,
     // Services
     lollipopService: mockedLollipopService,

--- a/apps/session-manager/src/server.ts
+++ b/apps/session-manager/src/server.ts
@@ -4,9 +4,8 @@ import * as O from "fp-ts/Option";
 import { pipe } from "fp-ts/lib/function";
 
 import * as E from "fp-ts/Either";
-import { NodeEnvironmentEnum } from "@pagopa/ts-commons/lib/environment";
 import { newApp } from "./app";
-import { AppInsightsConfig, ENV } from "./config";
+import { AppInsightsConfig, isDevEnv } from "./config";
 import {
   StartupEventName,
   initAppInsights,
@@ -89,7 +88,7 @@ export const serverStarter = (
     });
 
     initHttpGracefulShutdown(server, app, {
-      development: ENV === NodeEnvironmentEnum.DEVELOPMENT,
+      development: isDevEnv,
       finally: () => {
         log.info("Server graceful shutdown complete.");
       },

--- a/apps/session-manager/src/server.ts
+++ b/apps/session-manager/src/server.ts
@@ -1,11 +1,12 @@
-import { Server } from "http";
 import * as appInsights from "applicationinsights";
 
 import * as O from "fp-ts/Option";
 import { pipe } from "fp-ts/lib/function";
 
+import * as E from "fp-ts/Either";
+import { NodeEnvironmentEnum } from "@pagopa/ts-commons/lib/environment";
 import { newApp } from "./app";
-import { AppInsightsConfig } from "./config";
+import { AppInsightsConfig, ENV } from "./config";
 import {
   StartupEventName,
   initAppInsights,
@@ -14,11 +15,17 @@ import {
 import { log } from "./utils/logger";
 import { getCurrentBackendVersion } from "./utils/package";
 import { TimeTracer } from "./utils/timer";
+import { RedisClientMode } from "./types/redis";
+import { initHttpGracefulShutdown } from "./utils/graceful-shutdown";
+import {
+  PORT,
+  SHUTDOWN_SIGNALS,
+  SHUTDOWN_TIMEOUT_MILLIS,
+} from "./config/server";
+import { AppWithRefresherTimer } from "./utils/express";
+import { RedisRepo } from "./repositories";
 
 const timer = TimeTracer();
-
-// eslint-disable-next-line turbo/no-undeclared-env-vars
-const port = process.env.WEBSITES_PORT ?? 3000;
 
 const maybeAppInsightsClient = pipe(
   AppInsightsConfig.APPINSIGHTS_CONNECTION_STRING,
@@ -33,44 +40,70 @@ const maybeAppInsightsClient = pipe(
   O.toUndefined,
 );
 
-newApp({ appInsightsClient: maybeAppInsightsClient })
-  .then((app) => {
-    const server = app
-      .listen(port, () => {
-        const startupTimeMs = timer.getElapsedMilliseconds();
+/**
+ * Utility method used to start the server using a Express Application.
+ * This is usefull to mocktesting the startup process whidout creating a real
+ * http server.
+ *
+ * @param appTask An async express App decorated with additional params
+ */
+export const serverStarter = (
+  appTask: Promise<AppWithRefresherTimer & RedisRepo.RedisRepositoryDeps>,
+) =>
+  appTask.then(({ app, startIdpMetadataRefreshTimer, redisClientSelector }) => {
+    // Initialize the handler for the graceful shutdown
+    app.on("server:stop", () => {
+      // Clear refresher interval
+      clearInterval(startIdpMetadataRefreshTimer);
+      // Graceful redis connection shutdown.
+      for (const client of redisClientSelector.select(RedisClientMode.ALL)) {
+        log.info(`Gracefully closing redis connection`);
 
-        log.info("Listening on port %d", port);
-        log.info(`Startup time: %sms`, startupTimeMs.toString());
-        pipe(
-          maybeAppInsightsClient,
-          O.fromNullable,
-          O.map((_) =>
-            trackStartupTime(_, StartupEventName.SERVER, startupTimeMs),
-          ),
-        );
-      })
-      .on("close", () => {
-        log.info("On close: emit 'server:stop' event");
-        const result = app.emit("server:stop");
-        log.info(
-          `On close: end emit 'server:stop' event. Listeners found: ${result}`,
-        );
+        client
+          .quit()
+          .catch((err) =>
+            log.error(
+              `An Error occurred closing the redis connection: [${
+                E.toError(err).message
+              }]`,
+            ),
+          );
+      }
 
-        maybeAppInsightsClient?.flush();
-        appInsights.dispose();
-      });
+      // Dispose the Application Insights client
+      maybeAppInsightsClient?.flush();
+      appInsights.dispose();
+    });
+    const server = app.listen(PORT, () => {
+      const startupTimeMs = timer.getElapsedMilliseconds();
 
-    process.on("SIGTERM", shutDown(server, "SIGTERM"));
-    process.on("SIGINT", shutDown(server, "SIGINT"));
-  })
-  .catch((err) => {
-    log.error("Error loading app: %s", err);
-    process.exit(1);
+      log.info("Listening on port %d", PORT);
+      log.info(`Startup time: %sms`, startupTimeMs.toString());
+      pipe(
+        maybeAppInsightsClient,
+        O.fromNullable,
+        O.map((_) =>
+          trackStartupTime(_, StartupEventName.SERVER, startupTimeMs),
+        ),
+      );
+    });
+
+    initHttpGracefulShutdown(server, app, {
+      development: ENV === NodeEnvironmentEnum.DEVELOPMENT,
+      finally: () => {
+        log.info("Server graceful shutdown complete.");
+      },
+      signals: SHUTDOWN_SIGNALS,
+      timeout: SHUTDOWN_TIMEOUT_MILLIS,
+    });
+    return app;
   });
 
-const shutDown = (server: Server, signal: string) => () => {
-  log.info(`${signal} signal received: closing HTTP server`);
-  server.close(() => {
-    log.info("HTTP server closed");
-  });
-};
+serverStarter(
+  newApp({
+    appInsightsClient: maybeAppInsightsClient,
+  }),
+).catch((err) => {
+  log.error("Error loading app: %s", err);
+  process.exit(1);
+});

--- a/apps/session-manager/src/utils/graceful-shutdown.ts
+++ b/apps/session-manager/src/utils/graceful-shutdown.ts
@@ -1,0 +1,32 @@
+import * as http from "http";
+import * as https from "https";
+import { Express } from "express";
+import GracefulShutdown from "http-graceful-shutdown";
+import { log } from "./logger";
+
+/**
+ * Initialize the graceful shutdown process adding utility logs and emit
+ * the server:stop event on the final step.
+ *
+ */
+export function initHttpGracefulShutdown(
+  server: http.Server | https.Server,
+  app: Express,
+  options: GracefulShutdown.Options,
+): void {
+  log.info("Initializing server graceful shutdown");
+  GracefulShutdown(server, {
+    ...options,
+    finally: () => {
+      if (options.finally) {
+        options.finally();
+      }
+      // Showdown sincronization via emitted event
+      log.info("On close: emit 'server:stop' event");
+      const result = app.emit("server:stop");
+      log.info(
+        `On close: end emit 'server:stop' event. Listeners found: ${result}`,
+      );
+    },
+  });
+}

--- a/apps/session-manager/src/utils/graceful-shutdown.ts
+++ b/apps/session-manager/src/utils/graceful-shutdown.ts
@@ -18,9 +18,7 @@ export function initHttpGracefulShutdown(
   GracefulShutdown(server, {
     ...options,
     finally: () => {
-      if (options.finally) {
-        options.finally();
-      }
+      options.finally?.();
       // Showdown sincronization via emitted event
       log.info("On close: emit 'server:stop' event");
       const result = app.emit("server:stop");

--- a/yarn.lock
+++ b/yarn.lock
@@ -1237,6 +1237,7 @@ __metadata:
     express: "npm:^4.19.2"
     fp-ts: "npm:^2.16.5"
     helmet: "npm:^7.1.0"
+    http-graceful-shutdown: "npm:^3.1.13"
     io-ts: "npm:^2.2.21"
     io-ts-types: "npm:^0.5.16"
     jose: "npm:^5.3.0"
@@ -5716,6 +5717,15 @@ __metadata:
     statuses: "npm:>= 1.5.0 < 2"
     toidentifier: "npm:1.0.1"
   checksum: 10c0/f01aeecd76260a6fe7f08e192fcbe9b2f39ed20fc717b852669a69930167053b01790998275c6297d44f435cf0e30edd50c05223d1bec9bc484e6cf35b2d6f43
+  languageName: node
+  linkType: hard
+
+"http-graceful-shutdown@npm:^3.1.13":
+  version: 3.1.13
+  resolution: "http-graceful-shutdown@npm:3.1.13"
+  dependencies:
+    debug: "npm:^4.3.4"
+  checksum: 10c0/56e4c80c2bd468f0b94e8316b9012cea1e273ca4973636f7b5514eea757e8e89dc3fac1f439e0c04492a1f021a7241ed15ba1ccd21f022600c5c34425b3033f6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add `http-gradeful-shutdown` lib
Handle graceful shutdown initialization
Refactor the server start code for better unit testing
<!--- Describe your changes in detail -->

#### Motivation and Context
When the server shutting down we need to complete the ongoing http request from the client and after that closing all the connection to the storages. To handle this job we are using `http-graceful-shutdown`. 
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
unit test was refactored to check that redis `quit` method is called on shutdown event `server:stop`.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
