### PR TITLE
[#IOPID-1906] Abortable Fetch on downstream API call

### DIFF
--- a/.changeset/forty-spiders-double.md
+++ b/.changeset/forty-spiders-double.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/io-session-manager": patch
+---
+
+Abortable fetch for downstream API

--- a/apps/session-manager/package.json
+++ b/apps/session-manager/package.json
@@ -82,6 +82,7 @@
         "eslint": "^8.57.0",
         "eslint-config-monorepo": "*",
         "eslint-plugin-prettier": "^5.1.3",
+        "mock-http-server": "^1.4.5",
         "prettier": "^3.2.5",
         "shx": "^0.3.2",
         "supertest": "^7.0.0",

--- a/apps/session-manager/src/config/fast-login.ts
+++ b/apps/session-manager/src/config/fast-login.ts
@@ -13,6 +13,7 @@ import { NonNegativeIntegerFromString } from "@pagopa/ts-commons/lib/numbers";
 import { Second } from "@pagopa/ts-commons/lib/units";
 import { getIsUserElegibleForfastLogin } from "../utils/fast-login";
 import { log } from "../utils/logger";
+import { getRequiredENVVar } from "../utils/environment";
 
 // LV FF variable
 export const FF_FAST_LOGIN = pipe(
@@ -60,3 +61,6 @@ log.info(
   "LV Long Session duration set to %s seconds",
   lvLongSessionDurationSecs,
 );
+
+export const FAST_LOGIN_API_KEY = getRequiredENVVar("FAST_LOGIN_API_KEY");
+export const FAST_LOGIN_API_URL = getRequiredENVVar("FAST_LOGIN_API_URL");

--- a/apps/session-manager/src/config/fn-app.ts
+++ b/apps/session-manager/src/config/fn-app.ts
@@ -1,0 +1,4 @@
+import { getRequiredENVVar } from "../utils/environment";
+
+export const FN_APP_API_URL = getRequiredENVVar("API_URL");
+export const FN_APP_API_KEY = getRequiredENVVar("API_KEY");

--- a/apps/session-manager/src/config/index.ts
+++ b/apps/session-manager/src/config/index.ts
@@ -10,6 +10,7 @@ import { log } from "../utils/logger";
 import { IoLoginHostUrl } from "../types/common";
 
 import * as BPDConfig from "./bpd";
+import * as FnAppConfig from "./fn-app";
 import * as FastLoginConfig from "./fast-login";
 import * as LockProfileConfig from "./lock-profile";
 import * as LoginConfig from "./login";
@@ -40,6 +41,7 @@ export const BACKEND_HOST = pipe(
 
 export {
   BPDConfig,
+  FnAppConfig,
   FastLoginConfig,
   LockProfileConfig,
   LoginConfig,

--- a/apps/session-manager/src/utils/__tests__/api-clients.spec.ts
+++ b/apps/session-manager/src/utils/__tests__/api-clients.spec.ts
@@ -19,19 +19,19 @@ vi.mock("../../repositories/fn-app-api", () => ({
 }));
 
 vi.mock("../../repositories/fast-login-api", () => ({
-  getFnFastLoginAPIClient: (_, __, ___, fetchApi) =>
+  getFnFastLoginAPIClient: (_, __, basePath, fetchApi) =>
     FastLoginClient({
       baseUrl: `http://localhost:${PORT}`,
-      basePath: "",
+      basePath,
       fetchApi,
     }),
 }));
 
 vi.mock("../../repositories/lollipop-api", () => ({
-  getLollipopApiClient: (_, __, ___, fetchApi) =>
+  getLollipopApiClient: (_, __, basePath, fetchApi) =>
     LollipopClient({
       baseUrl: `http://localhost:${PORT}`,
-      basePath: "",
+      basePath,
       fetchApi,
     }),
 }));
@@ -96,7 +96,7 @@ describe("initAPIClientsDependencies", () => {
     async () => {
       server.on({
         method: "POST",
-        path: `/pubkeys`,
+        path: `/api/v1/pubkeys`,
         reply: {
           status: 200,
           body: JSON.stringify({ foo: "bar" }),

--- a/apps/session-manager/src/utils/__tests__/api-clients.spec.ts
+++ b/apps/session-manager/src/utils/__tests__/api-clients.spec.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import ServerMock from "mock-http-server";
+import { AbortError } from "node-fetch";
+import { createClient as FnAppClient } from "@pagopa/io-functions-app-sdk/client";
+import { createClient as FastLoginClient } from "../../generated/fast-login-api/client";
+import { createClient as LollipopClient } from "../../generated/lollipop-api/client";
+import { aFiscalCode } from "../../__mocks__/user.mocks";
+import { DEFAULT_REQUEST_TIMEOUT_MS } from "../fetch";
+import { JwkPubKeyHashAlgorithmEnum } from "../../generated/lollipop-api/JwkPubKeyHashAlgorithm";
+import { aJwkPubKey } from "../../__mocks__/lollipop.mocks";
+
+const PORT = 9000;
+vi.mock("../../repositories/fn-app-api", () => ({
+  FnAppAPIClient: (_, __, fetchApi) =>
+    FnAppClient({
+      baseUrl: `http://localhost:${PORT}`,
+      fetchApi,
+    }),
+}));
+
+vi.mock("../../repositories/fast-login-api", () => ({
+  getFnFastLoginAPIClient: (_, __, ___, fetchApi) =>
+    FastLoginClient({
+      baseUrl: `http://localhost:${PORT}`,
+      basePath: "",
+      fetchApi,
+    }),
+}));
+
+vi.mock("../../repositories/lollipop-api", () => ({
+  getLollipopApiClient: (_, __, ___, fetchApi) =>
+    LollipopClient({
+      baseUrl: `http://localhost:${PORT}`,
+      basePath: "",
+      fetchApi,
+    }),
+}));
+
+import { initAPIClientsDependencies } from "../api-clients";
+
+describe("initAPIClientsDependencies", () => {
+  const server = new ServerMock({ host: "localhost", port: PORT }, undefined);
+  const expectedAbortError = new AbortError("The user aborted a request.");
+
+  beforeEach(async () => new Promise((resolve) => server.start(resolve)));
+
+  afterEach(async () => new Promise((resolve) => server.stop(resolve)));
+
+  test(
+    "The FnAppAPIClient should abort the request if the server responde slowly",
+    { timeout: DEFAULT_REQUEST_TIMEOUT_MS + 500 },
+    async () => {
+      server.on({
+        method: "GET",
+        path: `/api/v1/profiles/${aFiscalCode}`,
+        reply: {
+          status: 200,
+          body: JSON.stringify({ foo: "bar" }),
+        },
+        delay: DEFAULT_REQUEST_TIMEOUT_MS + 100,
+      });
+      const { fnAppAPIClient } = initAPIClientsDependencies();
+
+      await expect(
+        fnAppAPIClient.getProfile({
+          fiscal_code: aFiscalCode,
+        }),
+      ).rejects.toThrow(expectedAbortError);
+    },
+  );
+
+  test(
+    "The FnFastLoginAPIClient should abort the request if the server responde slowly",
+    { timeout: DEFAULT_REQUEST_TIMEOUT_MS + 500 },
+    async () => {
+      server.on({
+        method: "POST",
+        path: `/api/v1/nonce/generate`,
+        reply: {
+          status: 200,
+          body: JSON.stringify({ foo: "bar" }),
+        },
+        delay: DEFAULT_REQUEST_TIMEOUT_MS + 100,
+      });
+      const { fnFastLoginAPIClient } = initAPIClientsDependencies();
+
+      await expect(fnFastLoginAPIClient.generateNonce({})).rejects.toThrow(
+        expectedAbortError,
+      );
+    },
+  );
+
+  test(
+    "The FnFastLoginAPIClient should abort the request if the server responde slowly",
+    { timeout: DEFAULT_REQUEST_TIMEOUT_MS + 500 },
+    async () => {
+      server.on({
+        method: "POST",
+        path: `/pubkeys`,
+        reply: {
+          status: 200,
+          body: JSON.stringify({ foo: "bar" }),
+        },
+        delay: DEFAULT_REQUEST_TIMEOUT_MS + 100,
+      });
+      const { fnLollipopAPIClient } = initAPIClientsDependencies();
+
+      await expect(
+        fnLollipopAPIClient.reservePubKey({
+          body: {
+            algo: JwkPubKeyHashAlgorithmEnum.sha256,
+            pub_key: aJwkPubKey,
+          },
+        }),
+      ).rejects.toThrow(expectedAbortError);
+    },
+  );
+});

--- a/apps/session-manager/src/utils/api-clients.ts
+++ b/apps/session-manager/src/utils/api-clients.ts
@@ -1,4 +1,4 @@
-import { LollipopConfig } from "../config/index";
+import { FastLoginConfig, LollipopConfig } from "../config/index";
 import { FnAppRepo, FnFastLoginRepo, FnLollipopRepo } from "../repositories";
 import { getRequiredENVVar } from "./environment";
 import { httpOrHttpsApiFetch } from "./fetch";
@@ -6,16 +6,20 @@ import { httpOrHttpsApiFetch } from "./fetch";
 export const initAPIClientsDependencies: () => FnAppRepo.FnAppAPIRepositoryDeps &
   FnFastLoginRepo.FnFastLoginRepositoryDeps &
   FnLollipopRepo.LollipopApiDeps = () => {
-  // Create the API client for the Azure Functions App
+  // Create the API client for `io-functions-app`
   const fnAppAPIClient = FnAppRepo.FnAppAPIClient(
     getRequiredENVVar("API_URL"),
     getRequiredENVVar("API_KEY"),
     httpOrHttpsApiFetch,
   );
+  // Create the API client for `io-functions-fast-login`
   const fnFastLoginAPIClient = FnFastLoginRepo.getFnFastLoginAPIClient(
-    getRequiredENVVar("FAST_LOGIN_API_KEY"),
-    getRequiredENVVar("FAST_LOGIN_API_URL"),
+    FastLoginConfig.FAST_LOGIN_API_KEY,
+    FastLoginConfig.FAST_LOGIN_API_URL,
+    undefined,
+    httpOrHttpsApiFetch,
   );
+  // Create the API client for `io-functions-lollipop`
   const fnLollipopAPIClient = FnLollipopRepo.getLollipopApiClient(
     LollipopConfig.LOLLIPOP_API_KEY,
     LollipopConfig.LOLLIPOP_API_URL,

--- a/apps/session-manager/src/utils/api-clients.ts
+++ b/apps/session-manager/src/utils/api-clients.ts
@@ -16,7 +16,7 @@ export const initAPIClientsDependencies: () => FnAppRepo.FnAppAPIRepositoryDeps 
   const fnFastLoginAPIClient = FnFastLoginRepo.getFnFastLoginAPIClient(
     FastLoginConfig.FAST_LOGIN_API_KEY,
     FastLoginConfig.FAST_LOGIN_API_URL,
-    undefined,
+    "",
     httpOrHttpsApiFetch,
   );
   // Create the API client for `io-functions-lollipop`

--- a/apps/session-manager/src/utils/api-clients.ts
+++ b/apps/session-manager/src/utils/api-clients.ts
@@ -1,6 +1,5 @@
-import { FastLoginConfig, LollipopConfig } from "../config/index";
+import { FastLoginConfig, FnAppConfig, LollipopConfig } from "../config/index";
 import { FnAppRepo, FnFastLoginRepo, FnLollipopRepo } from "../repositories";
-import { getRequiredENVVar } from "./environment";
 import { httpOrHttpsApiFetch } from "./fetch";
 
 export const initAPIClientsDependencies: () => FnAppRepo.FnAppAPIRepositoryDeps &
@@ -8,8 +7,8 @@ export const initAPIClientsDependencies: () => FnAppRepo.FnAppAPIRepositoryDeps 
   FnLollipopRepo.LollipopApiDeps = () => {
   // Create the API client for `io-functions-app`
   const fnAppAPIClient = FnAppRepo.FnAppAPIClient(
-    getRequiredENVVar("API_URL"),
-    getRequiredENVVar("API_KEY"),
+    FnAppConfig.FN_APP_API_URL,
+    FnAppConfig.FN_APP_API_KEY,
     httpOrHttpsApiFetch,
   );
   // Create the API client for `io-functions-fast-login`

--- a/apps/session-manager/src/utils/fetch.ts
+++ b/apps/session-manager/src/utils/fetch.ts
@@ -6,7 +6,7 @@ import {
 import { Millisecond } from "@pagopa/ts-commons/lib/units";
 import { agent } from "@pagopa/ts-commons";
 
-const DEFAULT_REQUEST_TIMEOUT_MS = 10000 as Millisecond;
+export const DEFAULT_REQUEST_TIMEOUT_MS = 10000 as Millisecond;
 
 // Generic HTTP/HTTPS fetch with optional keepalive agent
 // @see https://github.com/pagopa/io-ts-commons/blob/master/src/agent.ts#L10

--- a/yarn.lock
+++ b/yarn.lock
@@ -1242,6 +1242,7 @@ __metadata:
     jose: "npm:^5.3.0"
     jsonwebtoken: "npm:^9.0.2"
     logform: "npm:^2.6.0"
+    mock-http-server: "npm:^1.4.5"
     monocle-ts: "npm:^2.3.13"
     newtype-ts: "npm:^0.3.5"
     node-fetch: "npm:^2.6.1"
@@ -2937,7 +2938,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"body-parser@npm:1.20.2, body-parser@npm:^1.20.2":
+"body-parser@npm:1.20.2, body-parser@npm:^1.18.1, body-parser@npm:^1.20.2":
   version: 1.20.2
   resolution: "body-parser@npm:1.20.2"
   dependencies:
@@ -3406,6 +3407,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"connect@npm:^3.4.0":
+  version: 3.7.0
+  resolution: "connect@npm:3.7.0"
+  dependencies:
+    debug: "npm:2.6.9"
+    finalhandler: "npm:1.1.2"
+    parseurl: "npm:~1.3.3"
+    utils-merge: "npm:1.0.1"
+  checksum: 10c0/f120c6116bb16a0a7d2703c0b4a0cd7ed787dc5ec91978097bf62aa967289020a9f41a9cd3c3276a7b92aaa36f382d2cd35fed7138fd466a55c8e9fdbed11ca8
+  languageName: node
+  linkType: hard
+
 "console-assert@npm:1.0.0":
   version: 1.0.0
   resolution: "console-assert@npm:1.0.0"
@@ -3727,6 +3740,13 @@ __metadata:
   version: 2.0.0
   resolution: "depd@npm:2.0.0"
   checksum: 10c0/58bd06ec20e19529b06f7ad07ddab60e504d9e0faca4bd23079fac2d279c3594334d736508dc350e06e510aba5e22e4594483b3a6562ce7c17dd797f4cc4ad2c
+  languageName: node
+  linkType: hard
+
+"depd@npm:~1.1.2":
+  version: 1.1.2
+  resolution: "depd@npm:1.1.2"
+  checksum: 10c0/acb24aaf936ef9a227b6be6d495f0d2eb20108a9a6ad40585c5bda1a897031512fef6484e4fdbb80bd249fdaa82841fa1039f416ece03188e677ba11bcfda249
   languageName: node
   linkType: hard
 
@@ -4992,6 +5012,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"finalhandler@npm:1.1.2":
+  version: 1.1.2
+  resolution: "finalhandler@npm:1.1.2"
+  dependencies:
+    debug: "npm:2.6.9"
+    encodeurl: "npm:~1.0.2"
+    escape-html: "npm:~1.0.3"
+    on-finished: "npm:~2.3.0"
+    parseurl: "npm:~1.3.3"
+    statuses: "npm:~1.5.0"
+    unpipe: "npm:~1.0.0"
+  checksum: 10c0/6a96e1f5caab085628c11d9fdceb82ba608d5e426c6913d4d918409baa271037a47f28fbba73279e8ad614f0b8fa71ea791d265e408d760793829edd8c2f4584
+  languageName: node
+  linkType: hard
+
 "finalhandler@npm:1.2.0":
   version: 1.2.0
   resolution: "finalhandler@npm:1.2.0"
@@ -5668,6 +5703,19 @@ __metadata:
     statuses: "npm:2.0.1"
     toidentifier: "npm:1.0.1"
   checksum: 10c0/fc6f2715fe188d091274b5ffc8b3657bd85c63e969daa68ccb77afb05b071a4b62841acb7a21e417b5539014dff2ebf9550f0b14a9ff126f2734a7c1387f8e19
+  languageName: node
+  linkType: hard
+
+"http-errors@npm:~1.8.1":
+  version: 1.8.1
+  resolution: "http-errors@npm:1.8.1"
+  dependencies:
+    depd: "npm:~1.1.2"
+    inherits: "npm:2.0.4"
+    setprototypeof: "npm:1.2.0"
+    statuses: "npm:>= 1.5.0 < 2"
+    toidentifier: "npm:1.0.1"
+  checksum: 10c0/f01aeecd76260a6fe7f08e192fcbe9b2f39ed20fc717b852669a69930167053b01790998275c6297d44f435cf0e30edd50c05223d1bec9bc484e6cf35b2d6f43
   languageName: node
   linkType: hard
 
@@ -7267,6 +7315,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mock-http-server@npm:^1.4.5":
+  version: 1.4.5
+  resolution: "mock-http-server@npm:1.4.5"
+  dependencies:
+    body-parser: "npm:^1.18.1"
+    connect: "npm:^3.4.0"
+    multiparty: "npm:^4.1.2"
+    underscore: "npm:^1.8.3"
+  checksum: 10c0/3475f1c212476b2859106126844390e781e554a660574c5d8130a8bb72723f2499733153454719eac2029e35b85e18052b821edc227c46868190dd5761559763
+  languageName: node
+  linkType: hard
+
 "module-details-from-path@npm:^1.0.3":
   version: 1.0.3
   resolution: "module-details-from-path@npm:1.0.3"
@@ -7301,6 +7361,17 @@ __metadata:
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: 10c0/d924b57e7312b3b63ad21fc5b3dc0af5e78d61a1fc7cfb5457edaf26326bf62be5307cc87ffb6862ef1c2b33b0233cdb5d4f01c4c958cc0d660948b65a287a48
+  languageName: node
+  linkType: hard
+
+"multiparty@npm:^4.1.2":
+  version: 4.2.3
+  resolution: "multiparty@npm:4.2.3"
+  dependencies:
+    http-errors: "npm:~1.8.1"
+    safe-buffer: "npm:5.2.1"
+    uid-safe: "npm:2.1.5"
+  checksum: 10c0/e878138463b37890790dba7562a25f6bcc8796add095e6d1e777d9a507ef835325a2781451bf2685529feaf51ea28213c09c419fb9718fb26d7f241e16161df4
   languageName: node
   linkType: hard
 
@@ -7574,6 +7645,15 @@ __metadata:
   dependencies:
     ee-first: "npm:1.1.1"
   checksum: 10c0/46fb11b9063782f2d9968863d9cbba33d77aa13c17f895f56129c274318b86500b22af3a160fe9995aa41317efcd22941b6eba747f718ced08d9a73afdb087b4
+  languageName: node
+  linkType: hard
+
+"on-finished@npm:~2.3.0":
+  version: 2.3.0
+  resolution: "on-finished@npm:2.3.0"
+  dependencies:
+    ee-first: "npm:1.1.1"
+  checksum: 10c0/c904f9e518b11941eb60279a3cbfaf1289bd0001f600a950255b1dede9fe3df8cd74f38483550b3bb9485165166acb5db500c3b4c4337aec2815c88c96fcc2ea
   languageName: node
   linkType: hard
 
@@ -8202,6 +8282,13 @@ __metadata:
   version: 0.4.0
   resolution: "quote@npm:0.4.0"
   checksum: 10c0/af534aaeeeca89119b123d2ff84ea94ca6b1c2faaa0da2ff9d5d853282ebf6d5e38904b041d27df9f23a46fa6f503d3ca0c245738a43f3df8a6f34171967f14c
+  languageName: node
+  linkType: hard
+
+"random-bytes@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "random-bytes@npm:1.0.0"
+  checksum: 10c0/71e7a600e0976e9ebc269793a0577d47b965fa678fcc9e9623e427f909d1b3669db5b3a178dbf61229f0724ea23dba64db389f0be0ba675c6a6b837c02f29b8f
   languageName: node
   linkType: hard
 
@@ -9181,6 +9268,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"statuses@npm:>= 1.5.0 < 2, statuses@npm:~1.5.0":
+  version: 1.5.0
+  resolution: "statuses@npm:1.5.0"
+  checksum: 10c0/e433900956357b3efd79b1c547da4d291799ac836960c016d10a98f6a810b1b5c0dcc13b5a7aa609a58239b5190e1ea176ad9221c2157d2fd1c747393e6b2940
+  languageName: node
+  linkType: hard
+
 "std-env@npm:^3.5.0":
   version: 3.7.0
   resolution: "std-env@npm:3.7.0"
@@ -9913,6 +10007,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uid-safe@npm:2.1.5":
+  version: 2.1.5
+  resolution: "uid-safe@npm:2.1.5"
+  dependencies:
+    random-bytes: "npm:~1.0.0"
+  checksum: 10c0/ec96862e859fd12175f3da7fda9d1359a2cf412fd521e10837cbdc6d554774079ce252f366981df9401283841c8924782f6dbee8f82a3a81f805ed8a8584595d
+  languageName: node
+  linkType: hard
+
 "ulid@npm:^2.3.0":
   version: 2.3.0
   resolution: "ulid@npm:2.3.0"
@@ -9941,7 +10044,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"underscore@npm:^1.12.1":
+"underscore@npm:^1.12.1, underscore@npm:^1.8.3":
   version: 1.13.6
   resolution: "underscore@npm:1.13.6"
   checksum: 10c0/5f57047f47273044c045fddeb8b141dafa703aa487afd84b319c2495de2e685cecd0b74abec098292320d518b267c0c4598e45aa47d4c3628d0d4020966ba521


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
All the clients now use an `AbortableFetch` with timeout
Fix base path of `fn-fast-login` removing the default `/` added by the codegen
<!--- Describe your changes in detail -->

#### Motivation and Context
To avoid that connection to downstream API component remain pending if the response is slow (the API call from the client App have a timeout added at application level and another added by the Application Gateway), now we use by default an `AbortableFetch` with 10 seconds timeout.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
unit test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

