### PR TITLE
[#IOPID-2451] fix: Use conn string instead of instrumentation key for fast-login

### DIFF
--- a/infra/resources/prod/function_lv.tf
+++ b/infra/resources/prod/function_lv.tf
@@ -106,7 +106,7 @@ module "function_lv" {
     local.function_lv.app_settings
   )
 
-  application_insights_connection_string = data.azurerm_application_insights.application_insights.instrumentation_key
+  application_insights_connection_string = data.azurerm_application_insights.application_insights.connection_string
 
   action_group_id = azurerm_monitor_action_group.error_action_group.id
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
[fix: use conn string instead of instrumentation key](https://github.com/pagopa/io-auth-n-identity-domain/pull/122/commits/d412ebecebcea86e94247527881980a87874b747)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The function is not working because the new module uses the appinsight connection string, not the instrumentation key.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
