### PR TITLE
[#IOPID-2535] Remove duplicated autoscale shared AppServicePlan

### DIFF
--- a/infra/resources/prod/function_ioweb_profile.tf
+++ b/infra/resources/prod/function_ioweb_profile.tf
@@ -162,58 +162,6 @@ module "function_web_profile" {
   tags = local.tags
 }
 
-module "function_web_profile_autoscale" {
-  depends_on = [azurerm_resource_group.function_web_profile_rg, module.function_web_profile]
-  source     = "github.com/pagopa/dx//infra/modules/azure_app_service_plan_autoscaler?ref=ab26f57ed34a614fd3fa496c7b521be9ecc88e1b"
-
-  resource_group_name = azurerm_resource_group.function_web_profile_rg.name
-  target_service = {
-    function_app_name = module.function_web_profile.function_app.function_app.name
-  }
-
-  scheduler = {
-    normal_load = {
-      minimum = 3
-      default = 3
-    },
-    maximum = 30
-  }
-
-  scale_metrics = {
-    requests = {
-      statistic_increase        = "Average"
-      time_window_increase      = 1
-      time_aggregation          = "Average"
-      upper_threshold           = 3000
-      increase_by               = 2
-      cooldown_increase         = 1
-      statistic_decrease        = "Average"
-      time_window_decrease      = 5
-      time_aggregation_decrease = "Average"
-      lower_threshold           = 2000
-      decrease_by               = 1
-      cooldown_decrease         = 1
-    }
-    cpu = {
-      upper_threshold           = 45
-      lower_threshold           = 30
-      increase_by               = 2
-      decrease_by               = 1
-      cooldown_increase         = 1
-      cooldown_decrease         = 20
-      statistic_increase        = "Average"
-      statistic_decrease        = "Average"
-      time_aggregation_increase = "Average"
-      time_aggregation_decrease = "Average"
-      time_window_increase      = 1
-      time_window_decrease      = 5
-    }
-    memory = null
-  }
-
-  tags = local.tags
-}
-
 // ----------------------------------------------------
 // Alerts
 // ----------------------------------------------------


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Remove duplicated autoscaler related to shard AppServicePlan
<!--- Describe your changes in detail -->

#### Motivation and Context
The shared app service plan has already an autoscale, defined in `io-infra` within [here](https://github.com/pagopa/io-infra/blob/main/src/domains/citizen-auth-app/10_function_public.tf#L116).
The PR https://github.com/pagopa/io-infra/pull/1336 will update metrics based on request coming from `io-web-profile-backend`.
Multiple autoscaler doesn't work.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
