### PR TITLE
[#IOPID-2739] Add `APPLICATION_INSIGHTS_CONNECTION_STRING` to `io-public`

### DIFF
--- a/infra/resources/prod/function_public.tf
+++ b/infra/resources/prod/function_public.tf
@@ -26,6 +26,8 @@ locals {
 
       VALIDATION_CALLBACK_URL = "https://api-app.io.pagopa.it/email_verification.html"
       CONFIRM_CHOICE_PAGE_URL = "https://api-app.io.pagopa.it/email_confirm.html"
+
+      APPINSIGHTS_INSTRUMENTATIONKEY = data.azurerm_application_insights.application_insights.instrumentation_key
     }
   }
 }
@@ -70,13 +72,19 @@ module "function_public" {
     {
       # BUG: the following variable is not set when application_insights_key is
       # defined
-      APPINSIGHTS_SAMPLING_PERCENTAGE = 5
+      APPINSIGHTS_SAMPLING_PERCENTAGE                                                                  = 5
+      AzureFunctionsJobHost__logging__applicationInsights__samplingSettings__minSamplingPercentage     = 5,
+      AzureFunctionsJobHost__logging__applicationInsights__samplingSettings__maxSamplingPercentage     = 5,
+      AzureFunctionsJobHost__logging__applicationInsights__samplingSettings__initialSamplingPercentage = 5
     }
   )
   slot_app_settings = merge(
     local.function_public.app_settings,
     {
-      APPINSIGHTS_SAMPLING_PERCENTAGE = 100
+      APPINSIGHTS_SAMPLING_PERCENTAGE                                                                  = 100
+      AzureFunctionsJobHost__logging__applicationInsights__samplingSettings__minSamplingPercentage     = 100,
+      AzureFunctionsJobHost__logging__applicationInsights__samplingSettings__maxSamplingPercentage     = 100,
+      AzureFunctionsJobHost__logging__applicationInsights__samplingSettings__initialSamplingPercentage = 100
     }
   )
 
@@ -84,7 +92,7 @@ module "function_public" {
     web = true
   }
 
-  application_insights_key = data.azurerm_application_insights.application_insights.instrumentation_key
+  application_insights_connection_string = data.azurerm_application_insights.application_insights.connection_string
 
   action_group_id = azurerm_monitor_action_group.error_action_group.id
 


### PR DESCRIPTION

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- Add `APPINSIGHTS_INSTRUMENTATIONKEY` into `app_settings`
- Add `AzureFunctionsJobHost__logging__applicationInsights__samplingSettings` variables
- Switch from `application_insights_key` to `application_insights_connection_string`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Application insights instrumentation key will be no longer supported by the DevEx appropriate module.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
