### PR TITLE
[#IOPID-3125] Sonar coverage exclusions configuration

### DIFF
--- a/apps/io-fast-login/sonar-project.properties
+++ b/apps/io-fast-login/sonar-project.properties
@@ -5,6 +5,7 @@ sonar.projectKey=pagopa_io-auth-n-identity-domain_fast-login
 sonar.sources=src
 sonar.sourceEncoding=UTF-8
 sonar.exclusions=**/__tests__/**,**/__mocks__/**
+sonar.coverage.exclusions=src/config.ts,src/main.ts
 sonar.verbose=true
 sonar.javascript.lcov.reportPaths=/github/workspace/apps/io-fast-login/coverage/lcov.info
 sonar.typescript.tsconfigPath=/github/workspace/apps/io-fast-login/tsconfig.json

--- a/apps/io-lollipop/sonar-project.properties
+++ b/apps/io-lollipop/sonar-project.properties
@@ -5,6 +5,7 @@ sonar.projectKey=pagopa_io-auth-n-identity-domain_lollipop
 sonar.sources=src
 sonar.sourceEncoding=UTF-8
 sonar.exclusions=**/__tests__/**,**/__mocks__/**,**/__integrations__/**
+sonar.coverage.exclusions=src/utils/config.ts,src/**/index.ts
 sonar.verbose=true
 sonar.javascript.lcov.reportPaths=/github/workspace/apps/io-lollipop/coverage/lcov.info
 sonar.typescript.tsconfigPath=/github/workspace/apps/io-lollipop/tsconfig.json

--- a/apps/io-profile/sonar-project.properties
+++ b/apps/io-profile/sonar-project.properties
@@ -5,6 +5,7 @@ sonar.projectKey=pagopa_io-auth-n-identity-domain_profile
 sonar.sources=src
 sonar.sourceEncoding=UTF-8
 sonar.exclusions=**/__tests__/**,**/__mocks__/**,**/__integrations__/**
+sonar.coverage.exclusions=src/config.ts,src/main.ts
 sonar.verbose=true
 sonar.javascript.lcov.reportPaths=/github/workspace/apps/io-profile/coverage/lcov.info
 sonar.typescript.tsconfigPath=/github/workspace/apps/io-profile/tsconfig.json

--- a/apps/io-public/sonar-project.properties
+++ b/apps/io-public/sonar-project.properties
@@ -5,6 +5,7 @@ sonar.projectKey=pagopa_io-auth-n-identity-domain_public
 sonar.sources=src
 sonar.sourceEncoding=UTF-8
 sonar.exclusions=**/__tests__/**,**/__mocks__/**
+sonar.coverage.exclusions=src/utils/config.ts,src/**/index.ts
 sonar.verbose=true
 sonar.javascript.lcov.reportPaths=/github/workspace/apps/io-public/coverage/lcov.info
 sonar.typescript.tsconfigPath=/github/workspace/apps/io-public/tsconfig.json

--- a/apps/io-session-manager-internal/sonar-project.properties
+++ b/apps/io-session-manager-internal/sonar-project.properties
@@ -5,6 +5,7 @@ sonar.projectKey=pagopa_io-auth-n-identity-domain_session-manager-internal
 sonar.sources=src
 sonar.sourceEncoding=UTF-8
 sonar.exclusions=**/__tests__/**,**/__mocks__/**,**/__integrations__/**
+sonar.coverage.exclusions=src/controllers/main.ts,src/utils/config.ts
 sonar.verbose=true
 sonar.javascript.lcov.reportPaths=/github/workspace/apps/io-session-manager-internal/coverage/lcov.info
 sonar.typescript.tsconfigPath=/github/workspace/apps/io-session-manager-internal/tsconfig.json

--- a/apps/io-web-profile/sonar-project.properties
+++ b/apps/io-web-profile/sonar-project.properties
@@ -5,6 +5,7 @@ sonar.projectKey=pagopa_io-auth-n-identity-domain_web-profile
 sonar.sources=src
 sonar.sourceEncoding=UTF-8
 sonar.exclusions=**/__tests__/**,**/__mocks__/**,**/__integrations__/**
+sonar.coverage.exclusions=src/**/index.ts,src/utils/config.ts
 sonar.verbose=true
 sonar.javascript.lcov.reportPaths=/github/workspace/apps/io-web-profile/coverage/lcov.info
 sonar.typescript.tsconfigPath=/github/workspace/apps/io-web-profile/tsconfig.json


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Update Sonar code coverage exclusions for
- `io-fast-login` 40e518d54f542a4a0e9e4324d2ec3ccff3e7d019
- `io-lollipop` 0a13a75daea0b71eb1d2ae9b0dc2d963431ab64f
- `io-profile` 5bd94126aaf20c57e53e8deea55508d77a9b7e14
- `io-public` daaf49f9a99703e8a14dad529c3261107cf6469d
- `io-session-manager-internal` 28594284b35c31c36494aab8d68dda0ac2618824
- `io-web-profile` 4a6a11c63ba57ae462bd8d0587e965ae664d4acd

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a changeset, which I've added.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
