### PR TITLE
[#IOPID-3266] Read io-fast-login audit log container name from config

### DIFF
--- a/.changeset/red-bobcats-grin.md
+++ b/.changeset/red-bobcats-grin.md
@@ -1,0 +1,5 @@
+---
+"io-fast-login": minor
+---
+
+Read audit log container name from config

--- a/apps/io-fast-login/README.md
+++ b/apps/io-fast-login/README.md
@@ -66,6 +66,7 @@ The following table contains the required ENV variables that the applicative req
 | LOLLIPOP_GET_ASSERTION_API_KEY     | API Key to authorize `getAssertion`           | string  |
 | LOLLIPOP_GET_ASSERTION_BASE_URL    | API Url for `getAssertion` operation          | string  |
 | FAST_LOGIN_AUDIT_CONNECTION_STRING | Audit logs blob connection string             | string  |
+| FAST_LOGIN_AUDIT_CONTAINER_NAME    | Audit logs blob container                     | string  |
 | FETCH_TIMEOUT_MS                   | (optional) Fetch Timeout for AbortableFetch   | number  |
 | SESSION_MANAGER_INTERNAL_API_KEY   | API Key to authorize `logout`                 | string  |
 | SESSION_MANAGER_INTERNAL_BASE_URL  | API Url for `logout` operation                | string  |

--- a/apps/io-fast-login/env.example
+++ b/apps/io-fast-login/env.example
@@ -20,6 +20,7 @@ APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=foo;IngestionEndpoint=h
 # Fast Login Audit log storage
 ###
 FAST_LOGIN_AUDIT_CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://fnstorage:10000/devstoreaccount1;QueueEndpoint=http://fnstorage:10001/devstoreaccount1;TableEndpoint=http://fnstorage:10002/devstoreaccount1;
+FAST_LOGIN_AUDIT_CONTAINER_NAME=logs
 
 # needed to connect to cosmosdb server
 NODE_TLS_REJECT_UNAUTHORIZED=0

--- a/apps/io-fast-login/src/config.ts
+++ b/apps/io-fast-login/src/config.ts
@@ -52,6 +52,7 @@ export type IConfig = t.TypeOf<typeof IConfig>;
 export const IConfig = t.intersection([
   t.interface({
     FAST_LOGIN_AUDIT_CONNECTION_STRING: NonEmptyString,
+    FAST_LOGIN_AUDIT_CONTAINER_NAME: NonEmptyString,
 
     // Default is 10 sec timeout
     FETCH_TIMEOUT_MS: withDefault(t.string, "10000").pipe(NumberFromString),

--- a/apps/io-fast-login/src/functions/__tests__/fast-login.spec.ts
+++ b/apps/io-fast-login/src/functions/__tests__/fast-login.spec.ts
@@ -7,7 +7,7 @@ import * as O from "fp-ts/Option";
 import * as azureStorage from "@pagopa/io-functions-commons/dist/src/utils/azure_storage";
 import * as TE from "fp-ts/lib/TaskEither";
 import * as mattrglobalUtils from "@mattrglobal/http-signatures/lib/verify/verifySignatureHeader";
-import { okAsync, errAsync, Result, ResultAsync } from "neverthrow";
+import { okAsync, errAsync } from "neverthrow";
 import { aFiscalCode, anotherFiscalCode } from "../__mocks__/general";
 import {
   aLollipopInvalidSignature,
@@ -46,6 +46,7 @@ const mockValidateSignature = vi
   .spyOn(mattrglobalUtils, "verifySignatureHeader")
   .mockReturnValue(okAsync({ verified: true }));
 
+// eslint-disable-next-line max-lines-per-function
 describe("Fast Login handler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -65,6 +66,7 @@ describe("Fast Login handler", () => {
       input: req,
       fnLollipopClient: mockedFnLollipopClient,
       blobService: mockBlobService,
+      containerName: "logs" as NonEmptyString,
       redisClientTask: mockRedisClientTask
     })();
     expect(mockValidateSignature).toHaveBeenCalled();
@@ -112,6 +114,7 @@ describe("Fast Login handler", () => {
       input: req,
       fnLollipopClient: mockedFnLollipopClient,
       blobService: mockBlobService,
+      containerName: "logs" as NonEmptyString,
       redisClientTask: mockRedisClientTask
     })();
     expect(mockValidateSignature).not.toHaveBeenCalled();
@@ -141,6 +144,7 @@ describe("Fast Login handler", () => {
       input: req,
       fnLollipopClient: mockedFnLollipopClient,
       blobService: mockBlobService,
+      containerName: "logs" as NonEmptyString,
       redisClientTask: mockRedisClientTask
     })();
     expect(mockValidateSignature).not.toHaveBeenCalled();
@@ -172,6 +176,7 @@ describe("Fast Login handler", () => {
       input: req,
       fnLollipopClient: mockedFnLollipopClient,
       blobService: mockBlobService,
+      containerName: "logs" as NonEmptyString,
       redisClientTask: mockRedisClientTask
     })();
     expect(mockValidateSignature).not.toHaveBeenCalled();
@@ -204,6 +209,7 @@ describe("Fast Login handler", () => {
       input: req,
       fnLollipopClient: mockedFnLollipopClient,
       blobService: mockBlobService,
+      containerName: "logs" as NonEmptyString,
       redisClientTask: mockRedisClientTask
     })();
     expect(E.isRight(result)).toBeTruthy();
@@ -243,6 +249,7 @@ describe("Fast Login handler", () => {
       input: req,
       fnLollipopClient: mockedFnLollipopClient,
       blobService: mockBlobService,
+      containerName: "logs" as NonEmptyString,
       redisClientTask: mockRedisClientTask
     })();
     expect(E.isRight(result)).toBeTruthy();
@@ -276,6 +283,7 @@ describe("Fast Login handler", () => {
       input: req,
       fnLollipopClient: mockedFnLollipopClient,
       blobService: mockBlobService,
+      containerName: "logs" as NonEmptyString,
       redisClientTask: mockRedisClientTask
     })();
     expect(mockValidateSignature).toHaveBeenCalled();
@@ -316,6 +324,7 @@ describe("Fast Login handler", () => {
         input: req,
         fnLollipopClient: mockedFnLollipopClient,
         blobService: mockBlobService,
+        containerName: "logs" as NonEmptyString,
         redisClientTask: mockRedisClientTask
       })();
       expect(mockValidateSignature).toHaveBeenCalled();
@@ -361,6 +370,7 @@ describe("Fast Login handler", () => {
         input: req,
         fnLollipopClient: mockedFnLollipopClient,
         blobService: mockBlobService,
+        containerName: "logs" as NonEmptyString,
         redisClientTask: mockRedisClientTask
       })();
       expect(mockValidateSignature).toHaveBeenCalled();
@@ -412,6 +422,7 @@ describe("Fast Login handler", () => {
       input: req,
       fnLollipopClient: mockedFnLollipopClient,
       blobService: mockBlobService,
+      containerName: "logs" as NonEmptyString,
       redisClientTask: mockRedisClientTask
     })();
     expect(mockValidateSignature).toHaveBeenCalled();
@@ -452,6 +463,7 @@ describe("Fast Login handler", () => {
       input: req,
       fnLollipopClient: mockedFnLollipopClient,
       blobService: mockBlobService,
+      containerName: "logs" as NonEmptyString,
       redisClientTask: mockRedisClientTask
     })();
     expect(mockValidateSignature).toHaveBeenCalled();
@@ -488,6 +500,7 @@ describe("Fast Login handler", () => {
       input: req,
       fnLollipopClient: mockedFnLollipopClient,
       blobService: mockBlobService,
+      containerName: "logs" as NonEmptyString,
       redisClientTask: TE.left(new Error(anError))
     })();
     expect(mockValidateSignature).toHaveBeenCalled();
@@ -524,6 +537,7 @@ describe("Fast Login handler", () => {
       input: req,
       fnLollipopClient: mockedFnLollipopClient,
       blobService: mockBlobService,
+      containerName: "logs" as NonEmptyString,
       redisClientTask: mockRedisClientTask
     })();
     expect(mockValidateSignature).toHaveBeenCalled();

--- a/apps/io-fast-login/src/functions/fast-login.ts
+++ b/apps/io-fast-login/src/functions/fast-login.ts
@@ -89,14 +89,15 @@ export const StoreFastLoginAuditLogs: (
   H.HttpError,
   azureStorage.BlobService.BlobResult
 > = (fastLoginAuditLogDoc: FastLoginAuditDoc, logFileName: string) => ({
-  blobService
+  blobService,
+  containerName
 }) =>
   pipe(
     TE.tryCatch(
       () =>
         upsertBlobFromObject(
           blobService,
-          "logs",
+          containerName,
           logFileName,
           FastLoginAuditDoc.encode(fastLoginAuditLogDoc)
         ),

--- a/apps/io-fast-login/src/main.ts
+++ b/apps/io-fast-login/src/main.ts
@@ -63,6 +63,7 @@ const redisClientTask = CreateRedisClientSingleton(config);
 export const Info = InfoFunction({ redisClientTask });
 export const FastLogin = FastLoginFunction({
   blobService,
+  containerName: config.FAST_LOGIN_AUDIT_CONTAINER_NAME,
   fnLollipopClient,
   redisClientTask
 });

--- a/apps/io-fast-login/src/utils/lollipop/dependency.ts
+++ b/apps/io-fast-login/src/utils/lollipop/dependency.ts
@@ -1,4 +1,5 @@
 import { BlobService } from "azure-storage";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { Client } from "../../generated/definitions/fn-lollipop/client";
 import { RedisDependency } from "../redis/dependency";
 
@@ -6,4 +7,5 @@ export type FnLollipopClient = Client<"ApiKeyAuth">;
 export type FnLollipopClientDependency = {
   readonly fnLollipopClient: FnLollipopClient;
   readonly blobService: BlobService;
+  readonly containerName: NonEmptyString;
 } & RedisDependency;

--- a/docker/io-fast-login/env-dev
+++ b/docker/io-fast-login/env-dev
@@ -26,7 +26,7 @@ LOLLIPOP_GET_ASSERTION_BASE_URL=http://host.docker.internal
 # Fast Login Audit log storage
 ###
 FAST_LOGIN_AUDIT_CONNECTION_STRING=${STORAGE_CONN_STRING}
-
+FAST_LOGIN_AUDIT_CONTAINER_NAME=logs
 
 ###
 # SessionManagerInternal

--- a/infra/resources/prod/function_lv.tf
+++ b/infra/resources/prod/function_lv.tf
@@ -37,6 +37,7 @@ locals {
       //  Fast login audit log storage
       // --------------------------
       FAST_LOGIN_AUDIT_CONNECTION_STRING = data.azurerm_storage_account.immutable_lv_audit_logs_storage.primary_connection_string
+      FAST_LOGIN_AUDIT_CONTAINER_NAME    = "logs"
 
       // --------------------------
       //  Config for session manager internal connection


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

- [read container name from config](https://github.com/pagopa/io-auth-n-identity-domain/commit/61b954d52154aa9270eef8321211853ad99efe2e)
- [add container name to function app_settings](https://github.com/pagopa/io-auth-n-identity-domain/commit/b2d0bbfa9356289a1a09fb4a8649bb6af47b01dd)
- [update docs and env examples](https://github.com/pagopa/io-auth-n-identity-domain/commit/9305fa4af24bb3575a4cf256461d7e07f1c08260)
- [add CHANGESET](https://github.com/pagopa/io-auth-n-identity-domain/commit/0bedcb9fb69a8635fac1448e39702193e3ef096c)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Unlock audit log container migration to ITN

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a changeset, which I've added.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
