### PR TITLE
[CES-1130] Migrate lollipop refs to new KV

### DIFF
--- a/infra/resources/prod/README.md
+++ b/infra/resources/prod/README.md
@@ -55,6 +55,7 @@
 | [azurerm_key_vault_access_policy.kv_common_func_profas_staging](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_secret.citizen_auth_common_connection_string](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.cosmos_api_connection_string](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.cosmos_auth_connection_string](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.iopstapp_connection_string](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.iopstlogs_connection_string](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_monitor_action_group.error_action_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |

--- a/infra/resources/prod/function_lollipop.tf
+++ b/infra/resources/prod/function_lollipop.tf
@@ -26,7 +26,7 @@ locals {
       COSMOSDB_NAME                = "citizen-auth"
       COSMOSDB_URI                 = data.azurerm_cosmosdb_account.cosmos_citizen_auth.endpoint
       COSMOSDB_KEY                 = data.azurerm_cosmosdb_account.cosmos_citizen_auth.primary_key
-      COSMOS_API_CONNECTION_STRING = azurerm_key_vault_secret.cosmos_api_connection_string.value
+      COSMOS_API_CONNECTION_STRING = azurerm_key_vault_secret.cosmos_auth_connection_string.value
 
       #TODO: move to new storage on itn
       LOLLIPOP_ASSERTION_STORAGE_CONNECTION_STRING = data.azurerm_storage_account.lollipop_assertion_storage.primary_connection_string

--- a/infra/resources/prod/kv_secrets.tf
+++ b/infra/resources/prod/kv_secrets.tf
@@ -50,6 +50,14 @@ resource "azurerm_key_vault_secret" "cosmos_api_connection_string" {
   tags = local.tags
 }
 
+resource "azurerm_key_vault_secret" "cosmos_auth_connection_string" {
+  name         = "cosmos-auth-connection-string"
+  key_vault_id = module.key_vaults.auth.id
+  value        = format("AccountEndpoint=%s;AccountKey=%s;", data.azurerm_cosmosdb_account.cosmos_citizen_auth.endpoint, data.azurerm_cosmosdb_account.cosmos_citizen_auth.primary_key)
+
+  tags = local.tags
+}
+
 resource "azurerm_key_vault_secret" "citizen_auth_common_connection_string" {
   name         = "citizen-auth-common-connection-string"
   key_vault_id = data.azurerm_key_vault.kv.id


### PR DESCRIPTION
Close CES-1130

Depends on https://github.com/pagopa/io-infra/pull/1586