### PR TITLE
Add managed identity audit logging behind a flag

### DIFF
--- a/apps/io-fast-login/env.example
+++ b/apps/io-fast-login/env.example
@@ -1,4 +1,5 @@
 COMPOSE_PROJECT_NAME=io-functions-fast-login
+USE_MANAGED_IDENTITY=false
 SLOT_TASK_HUBNAME=FnFastLoginSlotTaskName
 ###
 # Docker Compose Envs

--- a/apps/io-fast-login/package.json
+++ b/apps/io-fast-login/package.json
@@ -48,6 +48,8 @@
   },
   "dependencies": {
     "@azure/functions": "catalog:",
+    "@azure/identity": "catalog:",
+    "@azure/storage-blob": "catalog:",
     "@mattrglobal/http-signatures": "catalog:",
     "@pagopa/handler-kit": "catalog:",
     "@pagopa/handler-kit-azure-func": "catalog:",
@@ -57,7 +59,6 @@
     "@pagopa/ts-commons": "catalog:",
     "@xmldom/xmldom": "catalog:",
     "applicationinsights": "catalog:",
-    "azure-storage": "catalog:",
     "date-fns": "catalog:",
     "fp-ts": "catalog:",
     "io-ts": "catalog:",

--- a/apps/io-fast-login/src/config.ts
+++ b/apps/io-fast-login/src/config.ts
@@ -51,7 +51,6 @@ export type RedisClientConfig = t.TypeOf<typeof RedisClientConfig>;
 export type IConfig = t.TypeOf<typeof IConfig>;
 export const IConfig = t.intersection([
   t.interface({
-    FAST_LOGIN_AUDIT_CONNECTION_STRING: NonEmptyString,
     FAST_LOGIN_AUDIT_CONTAINER_NAME: NonEmptyString,
 
     // Default is 10 sec timeout
@@ -59,7 +58,13 @@ export const IConfig = t.intersection([
 
     APPLICATIONINSIGHTS_CONNECTION_STRING: NonEmptyString,
 
+    USE_MANAGED_IDENTITY: t.boolean,
+
     isProduction: t.boolean
+  }),
+  t.partial({
+    FAST_LOGIN_AUDIT_CONNECTION_STRING: NonEmptyString,
+    FAST_LOGIN_AUDIT_STORAGE__blobServiceUri: NonEmptyString
   }),
   SessionManagerInternalConfig,
   GetAssertionConfig,
@@ -71,6 +76,7 @@ export const envConfig = {
   REDIS_TLS_ENABLED:
     process.env.REDIS_TLS_ENABLED &&
     process.env.REDIS_TLS_ENABLED.toLowerCase() === "true",
+  USE_MANAGED_IDENTITY: process.env.USE_MANAGED_IDENTITY !== "false",
   isProduction: process.env.NODE_ENV === "production"
 };
 

--- a/apps/io-fast-login/src/functions/__tests__/Info.spec.ts
+++ b/apps/io-fast-login/src/functions/__tests__/Info.spec.ts
@@ -1,15 +1,21 @@
 import { describe, expect, it, vi } from "vitest";
 import * as E from "fp-ts/lib/Either";
 import { HttpError } from "@pagopa/handler-kit";
+import { ContainerClient } from "@azure/storage-blob";
 import { makeInfoHandler } from "../info";
 import { httpHandlerInputMocks } from "../__mocks__/handlerMocks";
 import { mockRedisClientTask, mockPing } from "../__mocks__/redis";
+
+const mockAuditLogContainerClient = {
+  getProperties: vi.fn(async () => ({}))
+} as unknown as ContainerClient;
 
 describe("Info handler", () => {
   it("should return an error if Redis PING command fail", async () => {
     mockPing.mockRejectedValueOnce("db error");
     const result = await makeInfoHandler({
       ...httpHandlerInputMocks,
+      auditLogContainerClient: mockAuditLogContainerClient,
       redisClientTask: mockRedisClientTask
     })();
     expect(result).toMatchObject(
@@ -20,6 +26,7 @@ describe("Info handler", () => {
   it("should succeed if the application is healthy", async () => {
     const result = await makeInfoHandler({
       ...httpHandlerInputMocks,
+      auditLogContainerClient: mockAuditLogContainerClient,
       redisClientTask: mockRedisClientTask
     })();
 

--- a/apps/io-fast-login/src/functions/__tests__/fast-login.spec.ts
+++ b/apps/io-fast-login/src/functions/__tests__/fast-login.spec.ts
@@ -1,10 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as H from "@pagopa/handler-kit";
 import * as E from "fp-ts/Either";
+import { ContainerClient } from "@azure/storage-blob";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
-import { BlobService } from "azure-storage";
-import * as O from "fp-ts/Option";
-import * as azureStorage from "@pagopa/io-functions-commons/dist/src/utils/azure_storage";
 import * as TE from "fp-ts/lib/TaskEither";
 import * as mattrglobalUtils from "@mattrglobal/http-signatures/lib/verify/verifySignatureHeader";
 import { okAsync, errAsync } from "neverthrow";
@@ -28,19 +26,16 @@ const getAssertionMock = vi.fn(async () =>
     value: { response_xml: aSAMLResponse }
   })
 );
-const mockedFnLollipopClient = ({
+const mockedFnLollipopClient = {
   getAssertion: getAssertionMock
-} as unknown) as FnLollipopClient;
-const mockBlobService = ({} as unknown) as BlobService;
-const mockUpsertBlobFromObject = vi
-  .spyOn(azureStorage, "upsertBlobFromObject")
-  .mockResolvedValue(
-    E.right(
-      O.some({
-        created: true
-      } as any)
-    )
-  );
+} as unknown as FnLollipopClient;
+const mockUploadData = vi.fn(async () => ({ created: true }));
+const mockGetBlockBlobClient = vi.fn(() => ({
+  uploadData: mockUploadData
+}));
+const mockAuditLogContainerClient = {
+  getBlockBlobClient: mockGetBlockBlobClient
+} as unknown as ContainerClient;
 
 const mockValidateSignature = vi
   .spyOn(mattrglobalUtils, "verifySignatureHeader")
@@ -65,22 +60,22 @@ describe("Fast Login handler", () => {
       ...httpHandlerInputMocks,
       input: req,
       fnLollipopClient: mockedFnLollipopClient,
-      blobService: mockBlobService,
-      containerName: "logs" as NonEmptyString,
+      auditLogContainerClient: mockAuditLogContainerClient,
       redisClientTask: mockRedisClientTask
     })();
     expect(mockValidateSignature).toHaveBeenCalled();
     expect(mockDel).toHaveBeenCalled();
     expect(mockDel).toHaveBeenCalledWith(prefixer(aNonce));
     expect(getAssertionMock).toBeCalled();
-    expect(mockUpsertBlobFromObject).toBeCalled();
-    expect(mockUpsertBlobFromObject).toBeCalledWith(
-      {},
-      "logs",
-      // Check that the audit log filename starts with the fiscal code
+    expect(mockGetBlockBlobClient).toBeCalledWith(
       expect.stringMatching(
         new RegExp(`^${validLollipopHeaders["x-pagopa-lollipop-user-id"]}-?`)
-      ),
+      )
+    );
+    expect(mockUploadData).toBeCalled();
+    expect(
+      JSON.parse(mockUploadData.mock.calls[0][0].toString("utf-8"))
+    ).toEqual(
       expect.objectContaining({
         assertion_xml: aSAMLResponse,
         client_ip: validFastLoginAdditionalHeaders["x-pagopa-lv-client-ip"],
@@ -113,14 +108,13 @@ describe("Fast Login handler", () => {
       ...httpHandlerInputMocks,
       input: req,
       fnLollipopClient: mockedFnLollipopClient,
-      blobService: mockBlobService,
-      containerName: "logs" as NonEmptyString,
+      auditLogContainerClient: mockAuditLogContainerClient,
       redisClientTask: mockRedisClientTask
     })();
     expect(mockValidateSignature).not.toHaveBeenCalled();
     expect(mockDel).not.toHaveBeenCalled();
     expect(getAssertionMock).not.toBeCalled();
-    expect(mockUpsertBlobFromObject).not.toBeCalled();
+    expect(mockUploadData).not.toBeCalled();
     expect(result).toMatchObject(
       E.right({
         statusCode: 400,
@@ -143,14 +137,13 @@ describe("Fast Login handler", () => {
       ...httpHandlerInputMocks,
       input: req,
       fnLollipopClient: mockedFnLollipopClient,
-      blobService: mockBlobService,
-      containerName: "logs" as NonEmptyString,
+      auditLogContainerClient: mockAuditLogContainerClient,
       redisClientTask: mockRedisClientTask
     })();
     expect(mockValidateSignature).not.toHaveBeenCalled();
     expect(mockDel).not.toHaveBeenCalled();
     expect(getAssertionMock).not.toBeCalled();
-    expect(mockUpsertBlobFromObject).not.toBeCalled();
+    expect(mockUploadData).not.toBeCalled();
     expect(result).toMatchObject(
       E.right({
         statusCode: 400,
@@ -175,14 +168,13 @@ describe("Fast Login handler", () => {
       ...httpHandlerInputMocks,
       input: req,
       fnLollipopClient: mockedFnLollipopClient,
-      blobService: mockBlobService,
-      containerName: "logs" as NonEmptyString,
+      auditLogContainerClient: mockAuditLogContainerClient,
       redisClientTask: mockRedisClientTask
     })();
     expect(mockValidateSignature).not.toHaveBeenCalled();
     expect(mockDel).not.toHaveBeenCalled();
     expect(getAssertionMock).not.toBeCalled();
-    expect(mockUpsertBlobFromObject).not.toBeCalled();
+    expect(mockUploadData).not.toBeCalled();
     expect(result).toMatchObject(
       E.right({
         statusCode: 400,
@@ -208,15 +200,14 @@ describe("Fast Login handler", () => {
       ...httpHandlerInputMocks,
       input: req,
       fnLollipopClient: mockedFnLollipopClient,
-      blobService: mockBlobService,
-      containerName: "logs" as NonEmptyString,
+      auditLogContainerClient: mockAuditLogContainerClient,
       redisClientTask: mockRedisClientTask
     })();
     expect(E.isRight(result)).toBeTruthy();
     expect(mockValidateSignature).not.toHaveBeenCalled();
     expect(mockDel).not.toHaveBeenCalled();
     expect(getAssertionMock).not.toBeCalled();
-    expect(mockUpsertBlobFromObject).not.toBeCalled();
+    expect(mockUploadData).not.toBeCalled();
     if (E.isRight(result)) {
       expect(result.right).toMatchObject({
         statusCode: 400,
@@ -248,15 +239,14 @@ describe("Fast Login handler", () => {
       ...httpHandlerInputMocks,
       input: req,
       fnLollipopClient: mockedFnLollipopClient,
-      blobService: mockBlobService,
-      containerName: "logs" as NonEmptyString,
+      auditLogContainerClient: mockAuditLogContainerClient,
       redisClientTask: mockRedisClientTask
     })();
     expect(E.isRight(result)).toBeTruthy();
     expect(mockValidateSignature).toHaveBeenCalled();
     expect(mockDel).not.toHaveBeenCalled();
     expect(getAssertionMock).not.toBeCalled();
-    expect(mockUpsertBlobFromObject).not.toBeCalled();
+    expect(mockUploadData).not.toBeCalled();
     expect(result).toMatchObject(
       E.right({
         statusCode: 401,
@@ -282,8 +272,7 @@ describe("Fast Login handler", () => {
       ...httpHandlerInputMocks,
       input: req,
       fnLollipopClient: mockedFnLollipopClient,
-      blobService: mockBlobService,
-      containerName: "logs" as NonEmptyString,
+      auditLogContainerClient: mockAuditLogContainerClient,
       redisClientTask: mockRedisClientTask
     })();
     expect(mockValidateSignature).toHaveBeenCalled();
@@ -323,15 +312,14 @@ describe("Fast Login handler", () => {
         ...httpHandlerInputMocks,
         input: req,
         fnLollipopClient: mockedFnLollipopClient,
-        blobService: mockBlobService,
-        containerName: "logs" as NonEmptyString,
+        auditLogContainerClient: mockAuditLogContainerClient,
         redisClientTask: mockRedisClientTask
       })();
       expect(mockValidateSignature).toHaveBeenCalled();
       expect(mockDel).toHaveBeenCalled();
       expect(mockDel).toHaveBeenCalledWith(prefixer(aNonce));
       expect(getAssertionMock).toBeCalled();
-      expect(mockUpsertBlobFromObject).not.toBeCalled();
+      expect(mockUploadData).not.toBeCalled();
       expect(result).toMatchObject(
         E.right({
           statusCode: 500,
@@ -342,22 +330,15 @@ describe("Fast Login handler", () => {
   );
 
   it.each`
-    WHEN                                      | upsertBlobFromObjectResult                    | expectedErrorMessage                                                 | resolve
-    ${"the blob storage returns no result"}   | ${E.right(O.none)}                            | ${"The audit log was not saved"}                                     | ${true}
-    ${"the blob sorage returns an error"}     | ${E.left(new Error("Storage Error Message"))} | ${"An error occurred saving the audit log: [Storage Error Message]"} | ${true}
-    ${"the blob sorage unexpectedly rejects"} | ${new Error("Unexpected error")}              | ${"Unexpected error: [Unexpected error]"}                            | ${false}
+    WHEN                                      | uploadError                           | expectedErrorMessage
+    ${"the blob storage upload rejects"}      | ${new Error("Storage Error Message")} | ${"Unexpected error: [Storage Error Message]"}
+    ${"the blob sorage unexpectedly rejects"} | ${new Error("Unexpected error")}      | ${"Unexpected error: [Unexpected error]"}
   `(
     `GIVEN a valid LolliPoP request
      WHEN $WHEN
      THEN an Internal Server Error response is returned`,
-    async ({ upsertBlobFromObjectResult, expectedErrorMessage, resolve }) => {
-      resolve
-        ? mockUpsertBlobFromObject.mockResolvedValueOnce(
-            upsertBlobFromObjectResult
-          )
-        : mockUpsertBlobFromObject.mockRejectedValueOnce(
-            upsertBlobFromObjectResult
-          );
+    async ({ uploadError, expectedErrorMessage }) => {
+      mockUploadData.mockRejectedValueOnce(uploadError);
       const req: H.HttpRequest = {
         ...H.request("https://api.test.it/"),
         headers: {
@@ -369,21 +350,22 @@ describe("Fast Login handler", () => {
         ...httpHandlerInputMocks,
         input: req,
         fnLollipopClient: mockedFnLollipopClient,
-        blobService: mockBlobService,
-        containerName: "logs" as NonEmptyString,
+        auditLogContainerClient: mockAuditLogContainerClient,
         redisClientTask: mockRedisClientTask
       })();
       expect(mockValidateSignature).toHaveBeenCalled();
       expect(mockDel).toHaveBeenCalled();
       expect(mockDel).toHaveBeenCalledWith(prefixer(aNonce));
       expect(getAssertionMock).toBeCalled();
-      expect(mockUpsertBlobFromObject).toBeCalled();
-      expect(mockUpsertBlobFromObject).toBeCalledWith(
-        {},
-        "logs",
+      expect(mockGetBlockBlobClient).toBeCalledWith(
         expect.stringMatching(
           new RegExp(`^${validLollipopHeaders["x-pagopa-lollipop-user-id"]}-?`)
-        ),
+        )
+      );
+      expect(mockUploadData).toBeCalled();
+      expect(
+        JSON.parse(mockUploadData.mock.calls[0][0].toString("utf-8"))
+      ).toEqual(
         expect.objectContaining({
           assertion_xml: aSAMLResponse,
           client_ip: validFastLoginAdditionalHeaders["x-pagopa-lv-client-ip"]
@@ -421,15 +403,14 @@ describe("Fast Login handler", () => {
       ...httpHandlerInputMocks,
       input: req,
       fnLollipopClient: mockedFnLollipopClient,
-      blobService: mockBlobService,
-      containerName: "logs" as NonEmptyString,
+      auditLogContainerClient: mockAuditLogContainerClient,
       redisClientTask: mockRedisClientTask
     })();
     expect(mockValidateSignature).toHaveBeenCalled();
     expect(mockDel).not.toHaveBeenCalled();
     expect(getAssertionMock).not.toHaveBeenCalled();
-    expect(mockUpsertBlobFromObject).not.toHaveBeenCalled();
-    expect(mockUpsertBlobFromObject).not.toHaveBeenCalled();
+    expect(mockUploadData).not.toHaveBeenCalled();
+    expect(mockUploadData).not.toHaveBeenCalled();
     expect(result).toEqual(
       E.right(
         expect.objectContaining({
@@ -462,15 +443,14 @@ describe("Fast Login handler", () => {
       ...httpHandlerInputMocks,
       input: req,
       fnLollipopClient: mockedFnLollipopClient,
-      blobService: mockBlobService,
-      containerName: "logs" as NonEmptyString,
+      auditLogContainerClient: mockAuditLogContainerClient,
       redisClientTask: mockRedisClientTask
     })();
     expect(mockValidateSignature).toHaveBeenCalled();
     expect(mockDel).not.toHaveBeenCalled();
     expect(getAssertionMock).not.toHaveBeenCalled();
-    expect(mockUpsertBlobFromObject).not.toHaveBeenCalled();
-    expect(mockUpsertBlobFromObject).not.toHaveBeenCalled();
+    expect(mockUploadData).not.toHaveBeenCalled();
+    expect(mockUploadData).not.toHaveBeenCalled();
     expect(result).toEqual(
       E.right(
         expect.objectContaining({
@@ -499,15 +479,14 @@ describe("Fast Login handler", () => {
       ...httpHandlerInputMocks,
       input: req,
       fnLollipopClient: mockedFnLollipopClient,
-      blobService: mockBlobService,
-      containerName: "logs" as NonEmptyString,
+      auditLogContainerClient: mockAuditLogContainerClient,
       redisClientTask: TE.left(new Error(anError))
     })();
     expect(mockValidateSignature).toHaveBeenCalled();
     expect(mockDel).not.toHaveBeenCalled();
     expect(getAssertionMock).not.toHaveBeenCalled();
-    expect(mockUpsertBlobFromObject).not.toHaveBeenCalled();
-    expect(mockUpsertBlobFromObject).not.toHaveBeenCalled();
+    expect(mockUploadData).not.toHaveBeenCalled();
+    expect(mockUploadData).not.toHaveBeenCalled();
     expect(result).toEqual(
       E.right(
         expect.objectContaining({
@@ -536,15 +515,14 @@ describe("Fast Login handler", () => {
       ...httpHandlerInputMocks,
       input: req,
       fnLollipopClient: mockedFnLollipopClient,
-      blobService: mockBlobService,
-      containerName: "logs" as NonEmptyString,
+      auditLogContainerClient: mockAuditLogContainerClient,
       redisClientTask: mockRedisClientTask
     })();
     expect(mockValidateSignature).toHaveBeenCalled();
     expect(mockDel).toHaveBeenCalled();
     expect(getAssertionMock).not.toHaveBeenCalled();
-    expect(mockUpsertBlobFromObject).not.toHaveBeenCalled();
-    expect(mockUpsertBlobFromObject).not.toHaveBeenCalled();
+    expect(mockUploadData).not.toHaveBeenCalled();
+    expect(mockUploadData).not.toHaveBeenCalled();
     expect(result).toEqual(
       E.right(
         expect.objectContaining({

--- a/apps/io-fast-login/src/functions/fast-login.ts
+++ b/apps/io-fast-login/src/functions/fast-login.ts
@@ -12,10 +12,9 @@ import {
   JwkPublicKey,
   JwkPublicKeyFromToken
 } from "@pagopa/ts-commons/lib/jwk";
+import { BlobUploadCommonResponse } from "@azure/storage-blob";
 import { DOMParser } from "@xmldom/xmldom";
 import * as E from "fp-ts/Either";
-import { upsertBlobFromObject } from "@pagopa/io-functions-commons/dist/src/utils/azure_storage";
-import * as azureStorage from "azure-storage";
 import * as t from "io-ts";
 import {
   RequiredHeaderMiddleware,
@@ -56,30 +55,33 @@ const RetrieveSAMLResponse: (
   FnLollipopClientDependency,
   H.HttpError,
   FastLoginResponse
-> = (lollipopHeaders: LollipopHeaders) => ({ fnLollipopClient }) =>
-  pipe(
-    TE.tryCatch(
-      () =>
-        fnLollipopClient.getAssertion({
-          assertion_ref: lollipopHeaders[ASSERTION_REF_HEADER_NAME],
-          ["x-pagopa-lollipop-auth"]: `Bearer ${lollipopHeaders["x-pagopa-lollipop-auth-jwt"]}` as LollipopAuthBearer
-        }),
-      () => new H.HttpError("Error calling the getAssertion endpoint")
-    ),
-    TE.chainEitherK(
-      E.mapLeft(_ => new H.HttpError("Unexpected response from fn-lollipop"))
-    ),
-    TE.chain(response =>
-      response.status === 200
-        ? TE.right(response.value)
-        : TE.left(new H.HttpError("Error retrieving the SAML Assertion"))
-    ),
-    TE.filterOrElse(
-      isAssertionSaml(lollipopHeaders["x-pagopa-lollipop-assertion-type"]),
-      () => new H.HttpError("OIDC Claims not supported yet.")
-    ),
-    TE.map(assertion => ({ saml_response: assertion.response_xml }))
-  );
+> =
+  (lollipopHeaders: LollipopHeaders) =>
+  ({ fnLollipopClient }) =>
+    pipe(
+      TE.tryCatch(
+        () =>
+          fnLollipopClient.getAssertion({
+            assertion_ref: lollipopHeaders[ASSERTION_REF_HEADER_NAME],
+            ["x-pagopa-lollipop-auth"]:
+              `Bearer ${lollipopHeaders["x-pagopa-lollipop-auth-jwt"]}` as LollipopAuthBearer
+          }),
+        () => new H.HttpError("Error calling the getAssertion endpoint")
+      ),
+      TE.chainEitherK(
+        E.mapLeft(_ => new H.HttpError("Unexpected response from fn-lollipop"))
+      ),
+      TE.chain(response =>
+        response.status === 200
+          ? TE.right(response.value)
+          : TE.left(new H.HttpError("Error retrieving the SAML Assertion"))
+      ),
+      TE.filterOrElse(
+        isAssertionSaml(lollipopHeaders["x-pagopa-lollipop-assertion-type"]),
+        () => new H.HttpError("OIDC Claims not supported yet.")
+      ),
+      TE.map(assertion => ({ saml_response: assertion.response_xml }))
+    );
 
 export const StoreFastLoginAuditLogs: (
   fastLoginAuditLogDoc: FastLoginAuditDoc,
@@ -87,34 +89,23 @@ export const StoreFastLoginAuditLogs: (
 ) => RTE.ReaderTaskEither<
   FnLollipopClientDependency,
   H.HttpError,
-  azureStorage.BlobService.BlobResult
-> = (fastLoginAuditLogDoc: FastLoginAuditDoc, logFileName: string) => ({
-  blobService,
-  containerName
-}) =>
-  pipe(
-    TE.tryCatch(
-      () =>
-        upsertBlobFromObject(
-          blobService,
-          containerName,
-          logFileName,
-          FastLoginAuditDoc.encode(fastLoginAuditLogDoc)
-        ),
-      err => new H.HttpError(`Unexpected error: [${E.toError(err).message}]`)
-    ),
-    TE.chainEitherK(
-      E.mapLeft(
-        err =>
-          new H.HttpError(
-            `An error occurred saving the audit log: [${err.message}]`
-          )
+  BlobUploadCommonResponse
+> =
+  (fastLoginAuditLogDoc: FastLoginAuditDoc, logFileName: string) =>
+  ({ auditLogContainerClient }) =>
+    pipe(
+      TE.tryCatch(
+        () =>
+          auditLogContainerClient
+            .getBlockBlobClient(logFileName)
+            .uploadData(
+              Buffer.from(
+                JSON.stringify(FastLoginAuditDoc.encode(fastLoginAuditLogDoc))
+              )
+            ),
+        err => new H.HttpError(`Unexpected error: [${E.toError(err).message}]`)
       )
-    ),
-    TE.chain(
-      TE.fromOption(() => new H.HttpError("The audit log was not saved"))
-    )
-  );
+    );
 
 type Verifier = (assertion: Document) => TE.TaskEither<H.HttpError, true>;
 
@@ -125,51 +116,50 @@ type Verifier = (assertion: Document) => TE.TaskEither<H.HttpError, true>;
  * @param {AssertionRef} assertionRefFromHeader The assertion ref from the HTTP Request header `x-pagopa-lollipop-assertion-ref`
  * @returns The Verifier function
  */
-export const getAssertionRefVsInRensponseToVerifier = (
-  pubKey: JwkPublicKey,
-  assertionRefFromHeader: AssertionRef
-): Verifier => (assertionDoc): ReturnType<Verifier> =>
-  pipe(
-    assertionDoc,
-    getRequestIDFromSamlResponse,
-    TE.fromOption(
-      () =>
-        new H.HttpError("Missing request id in the retrieved saml assertion.")
-    ),
-    TE.filterOrElse(
-      AssertionRef.is,
-      () =>
-        new H.HttpError(
-          "InResponseTo in the assertion do not contains a valid Assertion Ref."
+export const getAssertionRefVsInRensponseToVerifier =
+  (pubKey: JwkPublicKey, assertionRefFromHeader: AssertionRef): Verifier =>
+  (assertionDoc): ReturnType<Verifier> =>
+    pipe(
+      assertionDoc,
+      getRequestIDFromSamlResponse,
+      TE.fromOption(
+        () =>
+          new H.HttpError("Missing request id in the retrieved saml assertion.")
+      ),
+      TE.filterOrElse(
+        AssertionRef.is,
+        () =>
+          new H.HttpError(
+            "InResponseTo in the assertion do not contains a valid Assertion Ref."
+          )
+      ),
+      TE.bindTo("inResponseTo"),
+      TE.bind("algo", ({ inResponseTo }) =>
+        TE.of(getAlgoFromAssertionRef(inResponseTo))
+      ),
+      TE.chain(({ inResponseTo, algo }) =>
+        pipe(
+          pubKey,
+          calculateAssertionRef(algo),
+          TE.mapLeft(
+            e =>
+              new H.HttpError(
+                `Error calculating the hash of the provided public key: ${e.message}`
+              )
+          ),
+          TE.filterOrElse(
+            calcAssertionRef =>
+              calcAssertionRef === inResponseTo &&
+              assertionRefFromHeader === inResponseTo,
+            calcAssertionRef =>
+              new H.HttpError(
+                `The hash of provided public key do not match the InReponseTo in the assertion: fromSaml=${inResponseTo},fromPublicKey=${calcAssertionRef},fromHeader=${assertionRefFromHeader}`
+              )
+          )
         )
-    ),
-    TE.bindTo("inResponseTo"),
-    TE.bind("algo", ({ inResponseTo }) =>
-      TE.of(getAlgoFromAssertionRef(inResponseTo))
-    ),
-    TE.chain(({ inResponseTo, algo }) =>
-      pipe(
-        pubKey,
-        calculateAssertionRef(algo),
-        TE.mapLeft(
-          e =>
-            new H.HttpError(
-              `Error calculating the hash of the provided public key: ${e.message}`
-            )
-        ),
-        TE.filterOrElse(
-          calcAssertionRef =>
-            calcAssertionRef === inResponseTo &&
-            assertionRefFromHeader === inResponseTo,
-          calcAssertionRef =>
-            new H.HttpError(
-              `The hash of provided public key do not match the InReponseTo in the assertion: fromSaml=${inResponseTo},fromPublicKey=${calcAssertionRef},fromHeader=${assertionRefFromHeader}`
-            )
-        )
-      )
-    ),
-    TE.map(() => true as const)
-  );
+      ),
+      TE.map(() => true as const)
+    );
 
 /**
  * Check if the Fiscal Number included into the SAMLResponse match with the provided parameter.
@@ -177,64 +167,62 @@ export const getAssertionRefVsInRensponseToVerifier = (
  * @param {FiscalCode} fiscalCodeFromHeader The Fiscal Number from the HTTP Request header `x-pagopa-lollipop-user-id`
  * @returns The Verifier function
  */
-export const getAssertionUserIdVsCfVerifier = (
-  fiscalCodeFromHeader: FiscalCode
-): Verifier => (assertionDoc): ReturnType<Verifier> =>
-  pipe(
-    assertionDoc,
-    getFiscalNumberFromSamlResponse,
-    TE.fromOption(
-      () =>
-        new H.HttpError(
-          "Missing or invalid Fiscal Code in the retrieved saml assertion."
-        )
-    ),
-    TE.filterOrElse(
-      fiscalCodeFromAssertion =>
-        fiscalCodeFromAssertion === fiscalCodeFromHeader,
-      fiscalCodeFromAssertion =>
-        new H.HttpError(
-          `The provided user id do not match the fiscalNumber in the assertion: fromSaml=${fiscalCodeFromAssertion},fromHeader=${fiscalCodeFromHeader}`
-        )
-    ),
-    TE.map(() => true as const)
-  );
+export const getAssertionUserIdVsCfVerifier =
+  (fiscalCodeFromHeader: FiscalCode): Verifier =>
+  (assertionDoc): ReturnType<Verifier> =>
+    pipe(
+      assertionDoc,
+      getFiscalNumberFromSamlResponse,
+      TE.fromOption(
+        () =>
+          new H.HttpError(
+            "Missing or invalid Fiscal Code in the retrieved saml assertion."
+          )
+      ),
+      TE.filterOrElse(
+        fiscalCodeFromAssertion =>
+          fiscalCodeFromAssertion === fiscalCodeFromHeader,
+        fiscalCodeFromAssertion =>
+          new H.HttpError(
+            `The provided user id do not match the fiscalNumber in the assertion: fromSaml=${fiscalCodeFromAssertion},fromHeader=${fiscalCodeFromHeader}`
+          )
+      ),
+      TE.map(() => true as const)
+    );
 
 const deleteNonce: (
   lollipopHeaders: LollipopHeaders
-) => RTE.ReaderTaskEither<
-  FnLollipopClientDependency,
-  H.HttpError,
-  true
-> = lollipopHeaders => ({ redisClientTask }) =>
-  pipe(
-    TE.fromEither(
-      getNonceFromSignatureInput(lollipopHeaders["signature-input"])
-    ),
-    TE.mapLeft(
-      error =>
-        new CustomHttpUnauthorizedError(
-          `Invalid or missing nonce in request: [${error.message}]`
-        )
-    ),
-    TE.chain(nonce =>
-      pipe(
-        redisClientTask,
-        TE.mapLeft(errorToHttpError),
-        TE.chainW(
-          flow(
-            invalidate(nonce),
-            TE.mapLeft(
-              error =>
-                new CustomHttpUnauthorizedError(
-                  `Could not delete nonce: [${error.message}]`
-                )
+) => RTE.ReaderTaskEither<FnLollipopClientDependency, H.HttpError, true> =
+  lollipopHeaders =>
+  ({ redisClientTask }) =>
+    pipe(
+      TE.fromEither(
+        getNonceFromSignatureInput(lollipopHeaders["signature-input"])
+      ),
+      TE.mapLeft(
+        error =>
+          new CustomHttpUnauthorizedError(
+            `Invalid or missing nonce in request: [${error.message}]`
+          )
+      ),
+      TE.chain(nonce =>
+        pipe(
+          redisClientTask,
+          TE.mapLeft(errorToHttpError),
+          TE.chainW(
+            flow(
+              invalidate(nonce),
+              TE.mapLeft(
+                error =>
+                  new CustomHttpUnauthorizedError(
+                    `Could not delete nonce: [${error.message}]`
+                  )
+              )
             )
           )
         )
       )
-    )
-  );
+    );
 
 export const makeFastLoginHandler: H.Handler<
   H.HttpRequest,

--- a/apps/io-fast-login/src/functions/info.ts
+++ b/apps/io-fast-login/src/functions/info.ts
@@ -3,16 +3,37 @@ import * as Task from "fp-ts/lib/Task";
 import * as RA from "fp-ts/lib/ReadonlyArray";
 import * as H from "@pagopa/handler-kit";
 import * as RTE from "fp-ts/ReaderTaskEither";
+import * as TE from "fp-ts/TaskEither";
+import { ContainerClient } from "@azure/storage-blob";
 
 import {
   HealthProblem,
-  ProblemSource
+  ProblemSource,
+  toHealthProblems
 } from "@pagopa/io-functions-commons/dist/src/utils/healthcheck";
 import { httpAzureFunction } from "@pagopa/handler-kit-azure-func";
 import { ApplicationInfo } from "../generated/definitions/internal/ApplicationInfo";
 import { RedisDependency } from "../utils/redis/dependency";
 import { makeRedisDBHealthCheck } from "../utils/redis/health-check";
 import { HealthCheckBuilder } from "../utils/health-check";
+
+type AuditLogStorageDependency = {
+  readonly auditLogContainerClient: ContainerClient;
+};
+
+const makeAuditLogStorageHealthCheck = ({
+  auditLogContainerClient
+}: AuditLogStorageDependency) =>
+  pipe(
+    // This check is intentionally read-only because audit containers are immutable.
+    // It still validates the selected credential and target container before swap.
+    TE.tryCatch(
+      () => auditLogContainerClient.getProperties(),
+      () => new Error("Error reading audit log container properties")
+    ),
+    TE.mapLeft(toHealthProblems("AuditLogStorage" as const)),
+    TE.map(() => true)
+  );
 
 const applicativeValidation = RTE.getApplicativeReaderTaskValidation(
   Task.ApplicativePar,
@@ -22,10 +43,13 @@ const applicativeValidation = RTE.getApplicativeReaderTaskValidation(
 export const makeInfoHandler: H.Handler<
   H.HttpRequest,
   H.HttpResponse<ApplicationInfo, 200>,
-  RedisDependency
+  AuditLogStorageDependency & RedisDependency
 > = H.of((_: H.HttpRequest) =>
   pipe(
-    [makeRedisDBHealthCheck] as ReadonlyArray<HealthCheckBuilder>,
+    [
+      makeRedisDBHealthCheck,
+      makeAuditLogStorageHealthCheck
+    ] as ReadonlyArray<HealthCheckBuilder>,
     RA.sequence(applicativeValidation),
     RTE.map(() => H.successJson({ message: "it works!" })),
     RTE.mapLeft(problems => new H.HttpError(problems.join("\n\n")))

--- a/apps/io-fast-login/src/main.ts
+++ b/apps/io-fast-login/src/main.ts
@@ -6,7 +6,8 @@ import {
 } from "@pagopa/ts-commons/lib/fetch";
 import { agent } from "@pagopa/ts-commons";
 import { Millisecond } from "@pagopa/ts-commons/lib/units";
-import { createBlobService } from "azure-storage";
+import { DefaultAzureCredential } from "@azure/identity";
+import { BlobServiceClient } from "@azure/storage-blob";
 import { getConfigOrThrow } from "./config";
 import { InfoFunction } from "./functions/info";
 import { FastLoginFunction } from "./functions/fast-login";
@@ -35,9 +36,9 @@ const abortableFetch = AbortableFetch(httpApiFetch);
 
 const fnLollipopClient: FnLollipopClient = createClient({
   baseUrl: config.LOLLIPOP_GET_ASSERTION_BASE_URL.href,
-  fetchApi: (toFetch(
+  fetchApi: toFetch(
     setFetchTimeout(config.FETCH_TIMEOUT_MS as Millisecond, abortableFetch)
-  ) as unknown) as typeof fetch,
+  ) as unknown as typeof fetch,
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   withDefaults: op => params =>
     op({
@@ -46,24 +47,38 @@ const fnLollipopClient: FnLollipopClient = createClient({
     })
 });
 
-const blobService = createBlobService(
-  config.FAST_LOGIN_AUDIT_CONNECTION_STRING
-);
+const auditLogContainerClient = config.USE_MANAGED_IDENTITY
+  ? new BlobServiceClient(
+      config.FAST_LOGIN_AUDIT_STORAGE__blobServiceUri ??
+        (() => {
+          throw new Error(
+            "Missing FAST_LOGIN_AUDIT_STORAGE__blobServiceUri when USE_MANAGED_IDENTITY is enabled"
+          );
+        })(),
+      new DefaultAzureCredential()
+    ).getContainerClient(config.FAST_LOGIN_AUDIT_CONTAINER_NAME)
+  : BlobServiceClient.fromConnectionString(
+      config.FAST_LOGIN_AUDIT_CONNECTION_STRING ??
+        (() => {
+          throw new Error(
+            "Missing FAST_LOGIN_AUDIT_CONNECTION_STRING when USE_MANAGED_IDENTITY is disabled"
+          );
+        })()
+    ).getContainerClient(config.FAST_LOGIN_AUDIT_CONTAINER_NAME);
 
-const sessionManagerInternalClient = sessionManagerInternalCreateClient<
-  "ApiKeyAuth"
->({
-  baseUrl: config.SESSION_MANAGER_INTERNAL_BASE_URL.href,
-  fetchApi: (toFetch(
-    setFetchTimeout(config.FETCH_TIMEOUT_MS as Millisecond, abortableFetch)
-  ) as unknown) as typeof fetch,
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  withDefaults: op => params =>
-    op({
-      ...params,
-      ApiKeyAuth: config.SESSION_MANAGER_INTERNAL_API_KEY
-    })
-});
+const sessionManagerInternalClient =
+  sessionManagerInternalCreateClient<"ApiKeyAuth">({
+    baseUrl: config.SESSION_MANAGER_INTERNAL_BASE_URL.href,
+    fetchApi: toFetch(
+      setFetchTimeout(config.FETCH_TIMEOUT_MS as Millisecond, abortableFetch)
+    ) as unknown as typeof fetch,
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    withDefaults: op => params =>
+      op({
+        ...params,
+        ApiKeyAuth: config.SESSION_MANAGER_INTERNAL_API_KEY
+      })
+  });
 
 const redisClientTask = CreateRedisClientSingleton(config);
 
@@ -74,7 +89,7 @@ app.http("Info", {
   methods: ["GET"],
   authLevel: "anonymous",
   route: "info",
-  handler: InfoFunction({ redisClientTask })
+  handler: InfoFunction({ auditLogContainerClient, redisClientTask })
 });
 
 app.http("FastLogin", {
@@ -82,8 +97,7 @@ app.http("FastLogin", {
   authLevel: "function",
   route: "api/v1/fast-login",
   handler: FastLoginFunction({
-    blobService,
-    containerName: config.FAST_LOGIN_AUDIT_CONTAINER_NAME,
+    auditLogContainerClient,
     fnLollipopClient,
     redisClientTask
   })

--- a/apps/io-fast-login/src/utils/lollipop/dependency.ts
+++ b/apps/io-fast-login/src/utils/lollipop/dependency.ts
@@ -1,11 +1,9 @@
-import { BlobService } from "azure-storage";
-import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { ContainerClient } from "@azure/storage-blob";
 import { Client } from "../../generated/definitions/fn-lollipop/client";
 import { RedisDependency } from "../redis/dependency";
 
 export type FnLollipopClient = Client<"ApiKeyAuth">;
 export type FnLollipopClientDependency = {
   readonly fnLollipopClient: FnLollipopClient;
-  readonly blobService: BlobService;
-  readonly containerName: NonEmptyString;
+  readonly auditLogContainerClient: ContainerClient;
 } & RedisDependency;

--- a/apps/io-web-profile/env.example
+++ b/apps/io-web-profile/env.example
@@ -1,4 +1,5 @@
 APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=foo;IngestionEndpoint=http://localhost;LiveEndpoint=http://localhost
+USE_MANAGED_IDENTITY=false
 
 COMPOSE_PROJECT_NAME=io-web-profile-backend
 SLOT_TASK_HUBNAME=<FunctionsTemplateSlotTaskName>

--- a/apps/io-web-profile/package.json
+++ b/apps/io-web-profile/package.json
@@ -61,6 +61,7 @@
   "dependencies": {
     "@azure/cosmos": "^3.11.5",
     "@azure/functions": "catalog:",
+    "@azure/identity": "catalog:",
     "@azure/storage-blob": "^12.17.0",
     "@pagopa/io-functions-commons": "^30.0.0",
     "@pagopa/openapi-codegen-ts": "^12.1.2",

--- a/apps/io-web-profile/src/Info/__tests__/handler.test.ts
+++ b/apps/io-web-profile/src/Info/__tests__/handler.test.ts
@@ -21,7 +21,7 @@ describe("InfoHandler", () => {
       "failure 1" as HealthProblem<"Config">,
       "failure 2" as HealthProblem<"Config">
     ]);
-    const handler = InfoHandler(_ => healthCheck);
+    const handler = InfoHandler(_ => healthCheck, TE.of(true));
 
     const response = await handler();
 
@@ -29,10 +29,9 @@ describe("InfoHandler", () => {
   });
 
   it("should return a success if the application is healthy", async () => {
-    const healthCheck: HealthCheck<"AzureStorage" | "Config", true> = TE.of(
-      true
-    );
-    const handler = InfoHandler(() => healthCheck);
+    const healthCheck: HealthCheck<"AzureStorage" | "Config", true> =
+      TE.of(true);
+    const handler = InfoHandler(() => healthCheck, TE.of(true));
     const response = await handler();
 
     expect(response.kind).toBe("IResponseSuccessJson");

--- a/apps/io-web-profile/src/Info/handler.ts
+++ b/apps/io-web-profile/src/Info/handler.ts
@@ -8,6 +8,7 @@ import {
   ResponseErrorInternal,
   ResponseSuccessJson
 } from "@pagopa/ts-commons/lib/responses";
+import { ContainerClient } from "@azure/storage-blob";
 
 import { pipe } from "fp-ts/lib/function";
 import * as TE from "fp-ts/lib/TaskEither";
@@ -27,26 +28,43 @@ type HealthChecker = (
   config: unknown
 ) => healthcheck.HealthCheck<"AzureStorage" | "Config", true>;
 
-export const InfoHandler = (
-  checkApplicationHealth: HealthChecker
-): InfoHandler => (): Promise<
-  IResponseSuccessJson<ApplicationInfo> | IResponseErrorInternal
-> =>
-  pipe(
-    envConfig,
-    checkApplicationHealth,
-    TE.map(_ =>
-      ResponseSuccessJson({
-        name: getValueFromPackageJson("name"),
-        version: getCurrentBackendVersion()
-      })
-    ),
-    TE.mapLeft(problems => ResponseErrorInternal(problems.join("\n\n"))),
-    TE.toUnion
-  )();
+export const InfoHandler =
+  (
+    checkApplicationHealth: HealthChecker,
+    checkAuditStorageHealth: healthcheck.HealthCheck<"AuditLogStorage", true>
+  ): InfoHandler =>
+  (): Promise<IResponseSuccessJson<ApplicationInfo> | IResponseErrorInternal> =>
+    pipe(
+      envConfig,
+      checkApplicationHealth,
+      TE.chainW(() => checkAuditStorageHealth),
+      TE.map(_ =>
+        ResponseSuccessJson({
+          name: getValueFromPackageJson("name"),
+          version: getCurrentBackendVersion()
+        })
+      ),
+      TE.mapLeft(problems => ResponseErrorInternal(problems.join("\n\n"))),
+      TE.toUnion
+    )();
 
-export const Info = () => {
-  const handler = InfoHandler(healthcheck.checkApplicationHealth(IConfig, []));
+const makeAuditStorageHealthCheck = (
+  containerClient: ContainerClient
+): healthcheck.HealthCheck<"AuditLogStorage", true> =>
+  pipe(
+    TE.tryCatch(
+      () => containerClient.getProperties(),
+      error => error
+    ),
+    TE.map(() => true as const),
+    TE.mapLeft(healthcheck.toHealthProblems("AuditLogStorage" as const))
+  );
+
+export const Info = (containerClient: ContainerClient) => {
+  const handler = InfoHandler(
+    healthcheck.checkApplicationHealth(IConfig, []),
+    makeAuditStorageHealthCheck(containerClient)
+  );
 
   return wrapHandlerV4([], handler);
 };

--- a/apps/io-web-profile/src/__mocks__/config.mock.ts
+++ b/apps/io-web-profile/src/__mocks__/config.mock.ts
@@ -22,38 +22,35 @@ const iconfig = {
   FF_API_ENABLED: FeatureFlagEnum.ALL,
   isProduction: false,
   AUDIT_LOG_CONNECTION_STRING: auditLogConnectionString as NonEmptyString,
-  AUDIT_LOG_CONTAINER: auditLogContainer as NonEmptyString
+  AUDIT_LOG_CONTAINER: auditLogContainer as NonEmptyString,
+  USE_MANAGED_IDENTITY: false
 };
 
-const {
-  privateKey: hslPrivateKey,
-  publicKey: hslPublicKey
-} = generateKeyPairSync("rsa", {
-  modulusLength: 2048,
-  publicKeyEncoding: {
-    type: "spki",
-    format: "pem"
-  },
-  privateKeyEncoding: {
-    type: "pkcs8",
-    format: "pem"
-  }
-});
+const { privateKey: hslPrivateKey, publicKey: hslPublicKey } =
+  generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: {
+      type: "spki",
+      format: "pem"
+    },
+    privateKeyEncoding: {
+      type: "pkcs8",
+      format: "pem"
+    }
+  });
 
-const {
-  privateKey: exchangePrivateKey,
-  publicKey: exchangePublicKey
-} = generateKeyPairSync("rsa", {
-  modulusLength: 2048,
-  publicKeyEncoding: {
-    type: "spki",
-    format: "pem"
-  },
-  privateKeyEncoding: {
-    type: "pkcs8",
-    format: "pem"
-  }
-});
+const { privateKey: exchangePrivateKey, publicKey: exchangePublicKey } =
+  generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: {
+      type: "spki",
+      format: "pem"
+    },
+    privateKeyEncoding: {
+      type: "pkcs8",
+      format: "pem"
+    }
+  });
 
 const {
   privateKey: magicLinkPrimaryPrivateKey,
@@ -110,10 +107,13 @@ export const jwtConfig: JWTConfig = {
   EXCHANGE_JWT_SECONDARY_PUB_KEY: exchangePrivateKey as NonEmptyString,
   EXCHANGE_JWT_TTL: 900 as Second,
   MAGIC_LINK_JWE_ISSUER: magicLinkIssuer as NonEmptyString,
-  MAGIC_LINK_JWE_PRIMARY_PRIVATE_KEY: magicLinkPrimaryPrivateKey as NonEmptyString,
-  MAGIC_LINK_JWE_SECONDARY_PRIVATE_KEY: magicLinkSecondaryPrivateKey as NonEmptyString,
+  MAGIC_LINK_JWE_PRIMARY_PRIVATE_KEY:
+    magicLinkPrimaryPrivateKey as NonEmptyString,
+  MAGIC_LINK_JWE_SECONDARY_PRIVATE_KEY:
+    magicLinkSecondaryPrivateKey as NonEmptyString,
   MAGIC_LINK_JWE_PRIMARY_PUB_KEY: magicLinkPrimaryPublicKey as NonEmptyString,
-  MAGIC_LINK_JWE_SECONDARY_PUB_KEY: magicLinkSecondaryPublicKey as NonEmptyString,
+  MAGIC_LINK_JWE_SECONDARY_PUB_KEY:
+    magicLinkSecondaryPublicKey as NonEmptyString,
   MAGIC_LINK_JWE_TTL: 604800 as Second,
   MAGIC_LINK_BASE_URL: "http://localhost:3000/it/magic-link" as NonEmptyString
 };

--- a/apps/io-web-profile/src/main.ts
+++ b/apps/io-web-profile/src/main.ts
@@ -1,5 +1,7 @@
 import { app } from "@azure/functions";
+import { DefaultAzureCredential } from "@azure/identity";
 import { BlobServiceClient } from "@azure/storage-blob";
+
 import { getConfigOrThrow } from "./utils/config";
 import { initTelemetryClient } from "./utils/appinsights";
 import { getFastLoginClient } from "./clients/fastLoginClient";
@@ -22,18 +24,33 @@ initTelemetryClient();
 // ---------------------------------------------------------------------------
 // DEPENDENCY INITIALISATION
 // ---------------------------------------------------------------------------
-const containerClient = BlobServiceClient.fromConnectionString(
-  config.AUDIT_LOG_CONNECTION_STRING,
-).getContainerClient(config.AUDIT_LOG_CONTAINER);
+const containerClient = config.USE_MANAGED_IDENTITY
+  ? new BlobServiceClient(
+      config.AUDIT_LOG_STORAGE__blobServiceUri ??
+        (() => {
+          throw new Error(
+            "Missing AUDIT_LOG_STORAGE__blobServiceUri when USE_MANAGED_IDENTITY is enabled"
+          );
+        })(),
+      new DefaultAzureCredential()
+    ).getContainerClient(config.AUDIT_LOG_CONTAINER)
+  : BlobServiceClient.fromConnectionString(
+      config.AUDIT_LOG_CONNECTION_STRING ??
+        (() => {
+          throw new Error(
+            "Missing AUDIT_LOG_CONNECTION_STRING when USE_MANAGED_IDENTITY is disabled"
+          );
+        })()
+    ).getContainerClient(config.AUDIT_LOG_CONTAINER);
 
 const fastLoginClient = getFastLoginClient(
   config.FAST_LOGIN_API_KEY,
-  config.FAST_LOGIN_CLIENT_BASE_URL,
+  config.FAST_LOGIN_CLIENT_BASE_URL
 );
 
 const functionsAppClient = getFunctionsAppClient(
   config.FUNCTIONS_APP_API_KEY,
-  config.FUNCTIONS_APP_CLIENT_BASE_URL,
+  config.FUNCTIONS_APP_CLIENT_BASE_URL
 );
 
 // ---------------------------------------------------------------------------
@@ -43,28 +60,28 @@ app.http("Info", {
   methods: ["GET"],
   authLevel: "anonymous",
   route: "api/v1/info",
-  handler: Info(),
+  handler: Info(containerClient)
 });
 
 app.http("Exchange", {
   methods: ["POST"],
   authLevel: "function",
   route: "api/v1/exchange",
-  handler: getExchangeHandler(config, containerClient),
+  handler: getExchangeHandler(config, containerClient)
 });
 
 app.http("LockSession", {
   methods: ["POST"],
   authLevel: "function",
   route: "api/v1/lock-session",
-  handler: getLockSessionHandler(fastLoginClient, config, containerClient),
+  handler: getLockSessionHandler(fastLoginClient, config, containerClient)
 });
 
 app.http("Logout", {
   methods: ["POST"],
   authLevel: "function",
   route: "api/v1/logout",
-  handler: getLogoutHandler(fastLoginClient, config, containerClient),
+  handler: getLogoutHandler(fastLoginClient, config, containerClient)
 });
 
 app.http("MagicLink", {
@@ -76,27 +93,27 @@ app.http("MagicLink", {
     config.MAGIC_LINK_JWE_PRIMARY_PUB_KEY,
     config.MAGIC_LINK_JWE_TTL,
     config.MAGIC_LINK_BASE_URL,
-    containerClient,
-  ),
+    containerClient
+  )
 });
 
 app.http("Profile", {
   methods: ["GET"],
   authLevel: "function",
   route: "api/v1/profile",
-  handler: getProfileHandler(functionsAppClient, config),
+  handler: getProfileHandler(functionsAppClient, config)
 });
 
 app.http("SessionState", {
   methods: ["GET"],
   authLevel: "function",
   route: "api/v1/session-state",
-  handler: getSessionStateHandler(fastLoginClient, config),
+  handler: getSessionStateHandler(fastLoginClient, config)
 });
 
 app.http("UnlockSession", {
   methods: ["POST"],
   authLevel: "function",
   route: "api/v1/unlock-session",
-  handler: getUnlockSessionHandler(fastLoginClient, config, containerClient),
+  handler: getUnlockSessionHandler(fastLoginClient, config, containerClient)
 });

--- a/apps/io-web-profile/src/utils/config.ts
+++ b/apps/io-web-profile/src/utils/config.ts
@@ -77,13 +77,19 @@ export type FunctionsAppClientConfig = t.TypeOf<
 >;
 
 export const IConfig = t.intersection([
-  t.interface({
-    AUDIT_LOG_CONNECTION_STRING: NonEmptyString,
-    AUDIT_LOG_CONTAINER: NonEmptyString,
-    BETA_TESTERS: CommaSeparatedListOf(FiscalCode),
-    FF_API_ENABLED: withFallback(FeatureFlag, FeatureFlagEnum.NONE),
-    isProduction: t.boolean
-  }),
+  t.intersection([
+    t.interface({
+      AUDIT_LOG_CONTAINER: NonEmptyString,
+      BETA_TESTERS: CommaSeparatedListOf(FiscalCode),
+      FF_API_ENABLED: withFallback(FeatureFlag, FeatureFlagEnum.NONE),
+      USE_MANAGED_IDENTITY: t.boolean,
+      isProduction: t.boolean
+    }),
+    t.partial({
+      AUDIT_LOG_CONNECTION_STRING: NonEmptyString,
+      AUDIT_LOG_STORAGE__blobServiceUri: NonEmptyString
+    })
+  ]),
   JWTConfig,
   FastLoginClientConfig,
   FunctionsAppClientConfig,
@@ -92,6 +98,7 @@ export const IConfig = t.intersection([
 
 export const envConfig = {
   ...process.env,
+  USE_MANAGED_IDENTITY: process.env.USE_MANAGED_IDENTITY !== "false",
   isProduction: process.env.NODE_ENV === "production"
 };
 

--- a/infra/resources/prod/function_ioweb_profile.tf
+++ b/infra/resources/prod/function_ioweb_profile.tf
@@ -12,7 +12,8 @@ locals {
   function_ioweb_profile = {
     name = "webprof"
     app_settings = {
-      NODE_ENV = "production"
+      NODE_ENV             = "production"
+      USE_MANAGED_IDENTITY = "true"
 
       // Keepalive fields are all optionals
       FETCH_KEEPALIVE_ENABLED             = "true"

--- a/infra/resources/prod/function_lv.tf
+++ b/infra/resources/prod/function_lv.tf
@@ -5,7 +5,8 @@ locals {
     name = "lv"
 
     app_settings = {
-      NODE_ENV = "production"
+      NODE_ENV             = "production"
+      USE_MANAGED_IDENTITY = "true"
 
       // Keepalive fields are all optionals
       FETCH_KEEPALIVE_ENABLED             = "true"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -414,6 +414,12 @@ importers:
       '@azure/functions':
         specifier: 'catalog:'
         version: 4.7.0
+      '@azure/identity':
+        specifier: 'catalog:'
+        version: 4.10.1
+      '@azure/storage-blob':
+        specifier: 'catalog:'
+        version: 12.29.1
       '@mattrglobal/http-signatures':
         specifier: 'catalog:'
         version: 4.1.1
@@ -441,9 +447,6 @@ importers:
       applicationinsights:
         specifier: 'catalog:'
         version: 2.9.6
-      azure-storage:
-        specifier: 'catalog:'
-        version: 2.10.7
       date-fns:
         specifier: 'catalog:'
         version: 2.30.0
@@ -1270,6 +1273,9 @@ importers:
       '@azure/functions':
         specifier: 'catalog:'
         version: 4.7.0
+      '@azure/identity':
+        specifier: 'catalog:'
+        version: 4.10.1
       '@azure/storage-blob':
         specifier: ^12.17.0
         version: 12.29.1
@@ -7544,6 +7550,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:


### PR DESCRIPTION
## Why

This PR adds managed identity support to the `io-web-profile` and `io-fast-login` audit blob clients and enables it in deployed environments after PR1 has already provisioned the required RBAC and identity-based settings. Legacy connection-string settings remain deployed temporarily so rollback is a configuration change, not a code revert.

## What changed

- Added `USE_MANAGED_IDENTITY` feature flag to switch audit blob clients between managed identity and connection-string fallback
- Switched audit blob client initialization to `DefaultAzureCredential` plus blob service URI when the flag is enabled
- Replaced `io-fast-login` legacy `azure-storage` audit writer with `@azure/storage-blob`, which supports both `TokenCredential` and connection strings
- Added audit blob container property checks to the existing `/info` health flows for pre-swap managed identity validation
- Kept connection-string fallback paths for quick rollback and local Azurite development
- Updated local `env.example` files with `USE_MANAGED_IDENTITY=false`
- Set deployed environments to `USE_MANAGED_IDENTITY=true`
- Kept legacy connection-string settings in Terraform temporarily for rollback during the validation window

## Validation strategy

The health checks use the same selected blob container clients as the audit-log writers and call `getProperties()` on the target audit containers. This is intentionally read-only because the audit containers are immutable/compliance-sensitive; write capability is covered by Storage Blob Data Contributor RBAC and production canary/monitoring after swap.

## Rollback procedure

If authentication or authorization issues appear after deployment, set `USE_MANAGED_IDENTITY=false` in app settings and restart/recycle the app or slot. The old connection-string settings from PR1 remain deployed through this PR, so SDK clients resume using the connection string without a code revert.

## Application order

Apply this PR after PR1.

Depends on #735

## Rationale

By shipping the code changes after the RBAC/bootstrap PR, the required identity permissions already exist before production switches to managed identity. The feature flag provides a rollback safety net, and the health checks catch wrong endpoints, missing RBAC, or propagation issues before swap.

## Validation

- `pnpm install`
- `pnpm --filter io-web-profile typecheck`
- `pnpm --filter io-fast-login typecheck`
- `pnpm --filter io-web-profile test`
- `pnpm --filter io-fast-login test`
- `pnpm --filter io-web-profile lint:check`
- `pnpm --filter io-fast-login lint:check`
- `terraform -chdir=infra/resources/prod fmt -recursive`
- `terraform -chdir=infra/resources/prod validate -no-color`

## Changesets

No changeset was added because these packages are deployable applications and this migration is infrastructure/runtime configuration, not a published API/library contract change.
