### PR TITLE
Remove legacy audit connection string settings

### DIFF
--- a/infra/resources/prod/function_ioweb_profile.tf
+++ b/infra/resources/prod/function_ioweb_profile.tf
@@ -69,7 +69,6 @@ locals {
       // -------------------------
       // Audit Logs config
       // -------------------------
-      AUDIT_LOG_CONNECTION_STRING       = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.ioweb_kv_audit_st_connection_string.versionless_id})"
       AUDIT_LOG_CONTAINER               = local.immutable_audit_logs_container_name
       AUDIT_LOG_STORAGE__blobServiceUri = "https://${module.storage_accounts.audit.name}.blob.core.windows.net"
     }

--- a/infra/resources/prod/function_lv.tf
+++ b/infra/resources/prod/function_lv.tf
@@ -32,7 +32,6 @@ locals {
       // --------------------------
       //  Fast login audit log storage
       // --------------------------
-      FAST_LOGIN_AUDIT_CONNECTION_STRING       = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.audit_st_connection_string.versionless_id})"
       FAST_LOGIN_AUDIT_CONTAINER_NAME          = local.lv_audit_logs_container_name
       FAST_LOGIN_AUDIT_STORAGE__blobServiceUri = "https://${module.storage_accounts.audit.name}.blob.core.windows.net"
 


### PR DESCRIPTION
## Why

This PR finalizes the selected production infrastructure migration by removing the legacy audit connection-string app settings from Terraform after managed identity has been proven stable in production.

## What changed

- Removed `AUDIT_LOG_CONNECTION_STRING` from the deployed `io-web-profile` Function App settings
- Removed `FAST_LOGIN_AUDIT_CONNECTION_STRING` from the deployed `io-fast-login` Function App settings
- Kept `USE_MANAGED_IDENTITY`, identity-based blob service URI settings, and audit container names
- Kept the application-level connection-string fallback code and local `env.example` connection strings so local Azurite development can still use explicit connection strings
- Kept shared/unclear Key Vault connection-string secrets in place:
  - `audit-st-connection-string` is still used by other app settings in this repository
  - `ioweb-kv-audit-st-connection-string` is in the external ioweb Key Vault and should only be deleted after ownership/consumers are audited

## Application order

Apply this PR after PR2 has been deployed, observed for the agreed validation window, and confirmed stable in production.

Depends on #736

## Rationale

After managed identity is confirmed stable in production, Terraform no longer needs to provision the selected legacy audit connection-string app settings. Keeping the dual-mode application code avoids breaking local development scenarios that depend on Azurite/emulator connection strings.

## Validation

- `terraform -chdir=infra/resources/prod fmt -recursive`
- `terraform -chdir=infra/resources/prod validate -no-color`

## Changesets

No changeset was added because this PR only removes production Terraform wiring for already-migrated app settings.
