### PR TITLE
Add queue reader role to Session Manager

### DIFF
--- a/infra/resources/modules/session_manager/iam.tf
+++ b/infra/resources/modules/session_manager/iam.tf
@@ -40,13 +40,22 @@ module "ca_iam" {
     description          = "Allow Session Manager Container App to read the locked profiles table"
   }]
 
-  storage_queue = [{
-    storage_account_name = data.azurerm_storage_account.io_com.name
-    resource_group_name  = data.azurerm_storage_account.io_com.resource_group_name
-    queue_name           = data.azurerm_storage_queue.push_notifications.name
-    description          = "Allow Session Manager Container App to write to the IO-Communication notification queue"
-    role                 = "writer"
-  }]
+  storage_queue = [
+    {
+      storage_account_name = data.azurerm_storage_account.io_com.name
+      resource_group_name  = data.azurerm_storage_account.io_com.resource_group_name
+      queue_name           = data.azurerm_storage_queue.push_notifications.name
+      description          = "Allow Session Manager Container App to read from the IO-Communication notification queue"
+      role                 = "reader"
+    },
+    {
+      storage_account_name = data.azurerm_storage_account.io_com.name
+      resource_group_name  = data.azurerm_storage_account.io_com.resource_group_name
+      queue_name           = data.azurerm_storage_queue.push_notifications.name
+      description          = "Allow Session Manager Container App to write to the IO-Communication notification queue"
+      role                 = "writer"
+    }
+  ]
 
   # cosmos = [ # TODO: capire su quali DB necessita scrittura/lettura
   #   {


### PR DESCRIPTION
Grant the Session Manager Container App reader access to the push-notification Storage Queue while preserving its existing writer access. This enables the app to consume push-notification messages.