### PR TITLE
Enable subscription feed recovery by updating lease prefix and disabling dry run

### DIFF
--- a/infra/resources/prod/function_profile.tf
+++ b/infra/resources/prod/function_profile.tf
@@ -28,8 +28,8 @@ locals {
       SUBSCRIPTION_FEED_RECOVERY_START_DATE           = "2026-04-17T00:00:00.000Z"
       SUBSCRIPTION_FEED_RECOVERY_END_DATE             = "2026-06-18T23:59:59.999Z"
       SUBSCRIPTION_FEED_RECOVERY_LEASE_CONTAINER_NAME = "upsert-subfeed-leases"
-      SUBSCRIPTION_FEED_RECOVERY_LEASE_PREFIX         = "dryrun-01"
-      SUBSCRIPTION_FEED_RECOVERY_DRY_RUN              = "true"
+      SUBSCRIPTION_FEED_RECOVERY_LEASE_PREFIX         = "run-01"
+      SUBSCRIPTION_FEED_RECOVERY_DRY_RUN              = "false"
 
       MAIL_FROM            = "IO - l'app dei servizi pubblici <no-reply@io.italia.it>"
       DPO_EMAIL_ADDRESS    = "dpo@pagopa.it" //TODO: seems to not be used anymore
@@ -133,7 +133,7 @@ module "function_profile" {
   app_settings = merge(
     local.function_profile.app_settings,
     {
-      "AzureWebJobs.RecoverSubscriptionsFeed.Disabled" = "1"
+      "AzureWebJobs.RecoverSubscriptionsFeed.Disabled" = "0"
     }
   )
   slot_app_settings = merge(

--- a/infra/resources/prod/function_profile.tf
+++ b/infra/resources/prod/function_profile.tf
@@ -175,7 +175,7 @@ module "function_profile_autoscale" {
 
   scheduler = {
     normal_load = {
-      minimum = 4
+      minimum = 8
       default = 10
     },
     maximum = 30


### PR DESCRIPTION
#### List of Changes
Updated the lease prefix for subscription feed recovery and disabled the dry run mode to enable the recovery process.

#### Motivation and Context
These changes are necessary to allow the subscription feed recovery feature to function correctly by ensuring it operates in a live environment rather than a dry run.

#### How Has This Been Tested?
Tested in dry-run mode in production

#### Screenshots (if appropriate):

#### Types of changes
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a changeset, which I've added.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

