### PR TITLE
fix(infra): set `key_vault_secret_id` with `versionless_id`

### DIFF
--- a/infra/resources/modules/session_manager/ca.tf
+++ b/infra/resources/modules/session_manager/ca.tf
@@ -18,7 +18,7 @@ module "sm_ca" {
   secrets = [
     {
       name                = "REDIS_PASSWORD"
-      key_vault_secret_id = azurerm_key_vault_secret.sm_redis_access_key.id
+      key_vault_secret_id = azurerm_key_vault_secret.sm_redis_access_key.versionless_id
     },
   ]
 


### PR DESCRIPTION
This pull request makes a small update to the `sm_ca` module to use the versionless ID for the Redis access key secret in Azure Key Vault. This change ensures the latest version of the secret is always used.

- Updated the `secrets` configuration in `ca.tf` to reference `azurerm_key_vault_secret.sm_redis_access_key.versionless_id` instead of `.id` for the `REDIS_PASSWORD` secret.