### PR TITLE
Scale up GitHub private runner

### DIFF
--- a/infra/bootstrapper/prod/main.tf
+++ b/infra/bootstrapper/prod/main.tf
@@ -126,8 +126,8 @@ module "repo" {
     }
 
     use_github_app = true
-    cpu            = 1
-    memory         = "2Gi"
+    cpu            = 1.5
+    memory         = "3Gi"
   }
 
   private_dns_zone_resource_group_id = data.azurerm_resource_group.common_weu.id


### PR DESCRIPTION
Increase the GitHub private runner resources from 1 CPU and 2 GiB memory to 1.5 CPU and 3 GiB memory to provide additional capacity for CI workloads.