### PR TITLE
Disable subscription feed recovery and adjust autoscale minimum

### DIFF
--- a/infra/resources/prod/function_profile.tf
+++ b/infra/resources/prod/function_profile.tf
@@ -133,7 +133,7 @@ module "function_profile" {
   app_settings = merge(
     local.function_profile.app_settings,
     {
-      "AzureWebJobs.RecoverSubscriptionsFeed.Disabled" = "0"
+      "AzureWebJobs.RecoverSubscriptionsFeed.Disabled" = "1"
     }
   )
   slot_app_settings = merge(
@@ -175,7 +175,7 @@ module "function_profile_autoscale" {
 
   scheduler = {
     normal_load = {
-      minimum = 8
+      minimum = 4
       default = 10
     },
     maximum = 30


### PR DESCRIPTION
Adjust the configuration to disable the subscription feed recovery and modify the autoscale minimum setting. This change aims to optimize resource management and improve system performance.

#### List of Changes
- Disabled the subscription feed recovery by setting the corresponding configuration to "1".
- Reduced the autoscale minimum setting from 8 to 4.

#### Motivation and Context
Disabling the subscription feed recovery helps prevent unnecessary resource usage now that the subfeed recovory it's completed, while adjusting the autoscale minimum enhances efficiency in resource allocation.

#### How Has This Been Tested?
not tested

#### Screenshots (if appropriate):

#### Types of changes
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a changeset, which I've added.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

