### PR TITLE
Add Redis write permission to Session Manager

### DIFF
--- a/infra/resources/modules/session_manager/iam.tf
+++ b/infra/resources/modules/session_manager/iam.tf
@@ -39,6 +39,12 @@ module "ca_iam" {
     }
   ]
 
+  managed_redis = [{
+    id          = module.managed_redis.id
+    role        = "writer"
+    description = "Allow Session Manager Container App to read/write to the Azure Managed Redis cache"
+  }]
+
   # cosmos = [ # TODO: capire su quali DB necessita scrittura/lettura
   #   {
   #     account_name        = data.azurerm_cosmosdb_account.cosmos.name


### PR DESCRIPTION
Grant the Session Manager Container App writer access to the Azure Managed Redis cache so it can read and write cached data.

Resolves IOPID-4133