### PR TITLE
Add alert action group to managed Redis

### DIFF
--- a/infra/resources/modules/session_manager/redis.tf
+++ b/infra/resources/modules/session_manager/redis.tf
@@ -21,9 +21,7 @@ module "managed_redis" {
   log_analytics_workspace_id = var.log_analytics_workspace_id
 
   alerts = {
-    type = {
-      action_group_id = var.action_group_id
-    }
+    action_group_id = var.action_group_id
   }
 
   tags = var.tags

--- a/infra/resources/modules/session_manager/redis.tf
+++ b/infra/resources/modules/session_manager/redis.tf
@@ -20,5 +20,11 @@ module "managed_redis" {
 
   log_analytics_workspace_id = var.log_analytics_workspace_id
 
+  alerts = {
+    type = {
+      action_group_id = var.action_group_id
+    }
+  }
+
   tags = var.tags
 }

--- a/infra/resources/modules/session_manager/variables.tf
+++ b/infra/resources/modules/session_manager/variables.tf
@@ -79,6 +79,12 @@ variable "log_analytics_workspace_id" {
   description = "Log Analytics Workspace ID for monitoring"
 }
 
+variable "action_group_id" {
+  type        = string
+  description = "The ID of the Action Group to invoke when an alert is triggered"
+}
+
+
 
 ##############
 # Key Vaults #

--- a/infra/resources/prod/session_manager.tf
+++ b/infra/resources/prod/session_manager.tf
@@ -45,4 +45,6 @@ module "session_manager" {
     base_url  = "https://${module.function_session_manager_internal.function_app.function_app.default_hostname}"
     base_path = "/api/v1"
   }
+
+  action_group_id = azurerm_monitor_action_group.error_action_group.id
 }


### PR DESCRIPTION
Configure the Session Manager managed Redis module to use the production alert action group, enabling notifications when Redis alerts are triggered.

Resolves IOPID-4133