### PR TITLE
Feat: `getUserLollipopActivation`

### DIFF
--- a/.changeset/green-hotels-clean.md
+++ b/.changeset/green-hotels-clean.md
@@ -1,0 +1,5 @@
+---
+"io-session-manager-internal": minor
+---
+
+Add `getUserLollipopActivation`

--- a/apps/io-session-manager-internal/src/__mocks__/services/session-service.mock.ts
+++ b/apps/io-session-manager-internal/src/__mocks__/services/session-service.mock.ts
@@ -1,7 +1,7 @@
 import { vi } from "vitest";
 import * as RTE from "fp-ts/lib/ReaderTaskEither";
 import { SessionService } from "../../services/session-service";
-import { anUnlockedUserSessionState } from "../user.mock";
+import { anAssertionRef, anUnlockedUserSessionState } from "../user.mock";
 
 export const mockInvalidateUserSession = vi
   .fn()
@@ -25,6 +25,10 @@ export const mockGetUserSessionState = vi
   .fn()
   .mockReturnValue(RTE.right(anUnlockedUserSessionState));
 
+export const mockGetUserLollipopActivation = vi
+  .fn()
+  .mockReturnValue(RTE.right(anAssertionRef));
+
 export const SessionServiceMock: SessionService = {
   invalidateUserSession: mockInvalidateUserSession,
   getUserSession: mockGetUserSession,
@@ -32,4 +36,5 @@ export const SessionServiceMock: SessionService = {
   unlockUserAuthentication: mockUnlockUserAuthentication,
   deleteUserSession: mockDeleteUserSession,
   getUserSessionState: mockGetUserSessionState,
+  getUserLollipopActivation: mockGetUserLollipopActivation,
 };

--- a/apps/io-session-manager-internal/src/controllers/__tests__/get-lollipop-activation.test.ts
+++ b/apps/io-session-manager-internal/src/controllers/__tests__/get-lollipop-activation.test.ts
@@ -1,0 +1,105 @@
+import { describe, beforeEach, vi, it, expect } from "vitest";
+import * as RTE from "fp-ts/ReaderTaskEither";
+import * as TE from "fp-ts/lib/TaskEither";
+import * as E from "fp-ts/lib/Either";
+import { RedisClusterType } from "redis";
+import * as H from "@pagopa/handler-kit";
+import { makeGetUserLollipopActivationHandler } from "../get-lollipop-activation";
+import {
+  SessionServiceMock,
+  mockGetUserLollipopActivation,
+} from "../../__mocks__/services/session-service.mock";
+import { RedisRepository } from "../../repositories/redis";
+import { httpHandlerInputMocks } from "../__mocks__/handler.mock";
+import { toGenericError, toNotFoundError } from "../../utils/errors";
+import { anAssertionRef } from "../../__mocks__/user.mock";
+
+const aFiscalCode = "SPNDNL80R13C555X";
+
+const mockedDependencies = {
+  SessionService: SessionServiceMock,
+  // service is already mocked, no need to mock the repositories
+  RedisRepository: {} as RedisRepository,
+  SafeRedisClientTask: TE.of({} as RedisClusterType),
+};
+
+describe("Get User Lollipop Activation Handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should succeed returning the user lollipop assertion ref", async () => {
+    const req = {
+      ...H.request("mockUrl"),
+      path: {
+        fiscalCode: aFiscalCode,
+      },
+    };
+    const result = await makeGetUserLollipopActivationHandler({
+      ...httpHandlerInputMocks,
+      input: req,
+      ...mockedDependencies,
+    })();
+
+    expect(mockGetUserLollipopActivation).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject(
+      E.right(H.successJson({ assertion_ref: anAssertionRef })),
+    );
+  });
+
+  it("should return Bad request on invalid path param", async () => {
+    const req = {
+      ...H.request("mockUrl"),
+      path: {
+        fiscalCode: "invalid",
+      },
+    };
+    const result = await makeGetUserLollipopActivationHandler({
+      ...httpHandlerInputMocks,
+      input: req,
+      ...mockedDependencies,
+    })();
+
+    expect(result).toMatchObject(E.right({ body: { status: 400 } }));
+  });
+
+  it("should return 404 when the lollipop activation is not found", async () => {
+    const req = {
+      ...H.request("mockUrl"),
+      path: {
+        fiscalCode: aFiscalCode,
+      },
+    };
+    mockGetUserLollipopActivation.mockReturnValueOnce(
+      RTE.left(toNotFoundError("LollipopActivation")),
+    );
+    const result = await makeGetUserLollipopActivationHandler({
+      ...httpHandlerInputMocks,
+      input: req,
+      ...mockedDependencies,
+    })();
+
+    expect(result).toMatchObject(E.right({ body: { status: 404 } }));
+  });
+
+  it("should fail on service generic error", async () => {
+    const req = {
+      ...H.request("mockUrl"),
+      path: {
+        fiscalCode: aFiscalCode,
+      },
+    };
+
+    const anError = toGenericError("ERROR");
+    mockGetUserLollipopActivation.mockReturnValueOnce(RTE.left(anError));
+    const result = await makeGetUserLollipopActivationHandler({
+      ...httpHandlerInputMocks,
+      input: req,
+      ...mockedDependencies,
+    })();
+
+    expect(result).toMatchObject(
+      E.right({ body: { status: 500, title: anError.causedBy?.message } }),
+    );
+  });
+});

--- a/apps/io-session-manager-internal/src/controllers/get-lollipop-activation.ts
+++ b/apps/io-session-manager-internal/src/controllers/get-lollipop-activation.ts
@@ -1,0 +1,74 @@
+import { httpAzureFunction } from "@pagopa/handler-kit-azure-func";
+import * as H from "@pagopa/handler-kit";
+import * as TE from "fp-ts/lib/TaskEither";
+import * as RTE from "fp-ts/ReaderTaskEither";
+import { pipe } from "fp-ts/lib/function";
+import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { sequenceS } from "fp-ts/lib/Apply";
+import { OutputOf } from "io-ts";
+import { AssertionRef } from "../generated/definitions/internal/AssertionRef";
+import {
+  GetUserLollipopActivationDeps,
+  SessionService,
+} from "../services/session-service";
+import { RequiredPathParamMiddleware } from "../utils/middlewares/required-path-param";
+import { DomainErrorTypes } from "../utils/errors";
+
+type Dependencies = {
+  SessionService: SessionService;
+};
+
+export type LollipopActivationResponse = {
+  readonly assertion_ref: OutputOf<typeof AssertionRef>;
+};
+
+const getUserLollipopActivation: (
+  fiscalCode: FiscalCode,
+) => RTE.ReaderTaskEither<
+  Dependencies & GetUserLollipopActivationDeps,
+  H.HttpError | H.HttpNotFoundError,
+  H.HttpResponse<LollipopActivationResponse, 200>
+> = (fiscalCode) => (deps) =>
+  pipe(
+    deps,
+    deps.SessionService.getUserLollipopActivation(fiscalCode),
+    TE.map((assertionRef) =>
+      H.successJson({
+        assertion_ref: AssertionRef.encode(assertionRef),
+      }),
+    ),
+    TE.mapLeft((error) => {
+      switch (error.kind) {
+        case DomainErrorTypes.GENERIC_ERROR:
+          return new H.HttpError(error.causedBy?.message);
+        case DomainErrorTypes.NOT_FOUND:
+          return new H.HttpNotFoundError(error.causedBy?.message);
+      }
+    }),
+  );
+
+export const makeGetUserLollipopActivationHandler: H.Handler<
+  H.HttpRequest,
+  | H.HttpResponse<LollipopActivationResponse, 200>
+  | H.HttpResponse<H.ProblemJson, H.HttpErrorStatusCode>,
+  Dependencies & GetUserLollipopActivationDeps
+> = H.of((req: H.HttpRequest) =>
+  pipe(
+    req,
+    sequenceS(RTE.ApplyPar)({
+      fiscalCode: RequiredPathParamMiddleware(
+        FiscalCode,
+        "fiscalCode" as NonEmptyString,
+      ),
+    }),
+    RTE.fromTaskEither,
+    RTE.chain(({ fiscalCode }) => getUserLollipopActivation(fiscalCode)),
+    RTE.orElseW((error) =>
+      RTE.right(H.problemJson({ status: error.status, title: error.message })),
+    ),
+  ),
+);
+
+export const GetUserLollipopActivationFunction = httpAzureFunction(
+  makeGetUserLollipopActivationHandler,
+);

--- a/apps/io-session-manager-internal/src/controllers/main.ts
+++ b/apps/io-session-manager-internal/src/controllers/main.ts
@@ -173,6 +173,7 @@ app.http("DeleteUserSession", {
   route: `${v1BasePath}/sessions/{fiscalCode}/logout`,
 });
 
+// used to support the new session data model rollout plan
 app.http("GetUserLollipopActivation", {
   authLevel: "function",
   handler: GetUserLollipopActivationFunction({

--- a/apps/io-session-manager-internal/src/controllers/main.ts
+++ b/apps/io-session-manager-internal/src/controllers/main.ts
@@ -33,6 +33,7 @@ import {
 import { RejectedLoginEventProcessorFunction } from "./rejected-login-event-processor";
 import { PlatformInternalRepository } from "../repositories/platform-internal";
 import { getPlatformInternalApiClient } from "../utils/platform-internal-client";
+import { GetUserLollipopActivationFunction } from "./get-lollipop-activation";
 
 const v1BasePath = "api/v1";
 const config = getConfigOrThrow();
@@ -170,6 +171,17 @@ app.http("DeleteUserSession", {
   }),
   methods: ["POST"],
   route: `${v1BasePath}/sessions/{fiscalCode}/logout`,
+});
+
+app.http("GetUserLollipopActivation", {
+  authLevel: "function",
+  handler: GetUserLollipopActivationFunction({
+    SafeRedisClientTask: safeRedisClientTask,
+    SessionService,
+    RedisRepository,
+  }),
+  methods: ["GET"],
+  route: `${v1BasePath}/lollipop/{fiscalCode}/activation`,
 });
 
 // //////////////////////////////

--- a/apps/io-session-manager-internal/src/services/__tests__/session-service.test.ts
+++ b/apps/io-session-manager-internal/src/services/__tests__/session-service.test.ts
@@ -41,6 +41,7 @@ import {
   mockDeleteInstallation,
 } from "../../__mocks__/repositories/installation.mock";
 import {
+  anAssertionRef,
   anUnlockCode,
   anUnlockedUserSessionState,
   anotherUnlockCode,
@@ -50,6 +51,7 @@ import {
   forbiddenError,
   toConflictError,
   toGenericError,
+  toNotFoundError,
 } from "../../utils/errors";
 import { aNotReleasedData } from "../../__mocks__/table-client.mock";
 import { LoginTypeEnum } from "../../types/fast-login";
@@ -834,6 +836,66 @@ describe("Session Service#getUserSessionState", () => {
     expect(result).toEqual(
       E.left(
         toGenericError(`Error reading the session info: [${anErrorMessage}]`),
+      ),
+    );
+  });
+});
+
+describe("Session Service#getUserLollipopActivation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const deps = {
+    SafeRedisClientTask: RedisClientTaskMock,
+    RedisRepository: RedisRepositoryMock,
+  };
+
+  it("should succeed returning the user assertion ref", async () => {
+    const result =
+      await SessionService.getUserLollipopActivation(aFiscalCode)(deps)();
+
+    expect(mockGetLollipopAssertionRefForUser).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(E.right(anAssertionRef));
+  });
+
+  it("should return NotFoundError when no assertion ref is stored for the user", async () => {
+    mockGetLollipopAssertionRefForUser.mockReturnValueOnce(TE.right(O.none));
+
+    const result =
+      await SessionService.getUserLollipopActivation(aFiscalCode)(deps)();
+
+    expect(result).toEqual(E.left(toNotFoundError("LollipopActivation")));
+  });
+
+  it("should return generic error when redis is not available", async () => {
+    const anErrorMessage = "ERROR";
+    const expectedError = toGenericError(
+      `Could not establish connection to redis: ${anErrorMessage}`,
+    );
+
+    const result = await SessionService.getUserLollipopActivation(aFiscalCode)({
+      ...deps,
+      SafeRedisClientTask: TE.left(Error(anErrorMessage)),
+    })();
+
+    expect(result).toEqual(E.left(expectedError));
+  });
+
+  it("should return generic error when assertion ref retrieval fails", async () => {
+    const anErrorMessage = "ERROR";
+    mockGetLollipopAssertionRefForUser.mockReturnValueOnce(
+      TE.left(new Error(anErrorMessage)),
+    );
+
+    const result =
+      await SessionService.getUserLollipopActivation(aFiscalCode)(deps)();
+
+    expect(result).toEqual(
+      E.left(
+        toGenericError(
+          `Error reading the lollipop assertion ref: [${anErrorMessage}]`,
+        ),
       ),
     );
   });

--- a/apps/io-session-manager-internal/src/services/session-service.ts
+++ b/apps/io-session-manager-internal/src/services/session-service.ts
@@ -22,6 +22,7 @@ import {
 } from "@pagopa/io-auth-n-identity-commons/types/session-events/logout-event";
 
 import { TableClient } from "@azure/data-tables";
+import { AssertionRef } from "../generated/definitions/internal/AssertionRef";
 import { TypeEnum as LoginTypeEnum } from "../generated/definitions/internal/SessionInfo";
 import { SessionState } from "../generated/definitions/internal/SessionState";
 import { UnlockCode } from "../generated/definitions/internal/UnlockCode";
@@ -38,9 +39,11 @@ import {
   ConflictError,
   ForbiddenError,
   GenericError,
+  NotFoundError,
   forbiddenError,
   toConflictError,
   toGenericError,
+  toNotFoundError,
 } from "../utils/errors";
 import { PlatformInternalRepository } from "../repositories/platform-internal";
 import { PlatformInternalApiClient } from "../utils/platform-internal-client";
@@ -452,6 +455,43 @@ const emitLogoutEvent: (
       }),
     );
 
+export type GetUserLollipopActivationDeps = Pick<
+  RedisDeps,
+  "SafeRedisClientTask" | "RedisRepository"
+>;
+const getUserLollipopActivation: (
+  fiscalCode: FiscalCode,
+) => RTE.ReaderTaskEither<
+  GetUserLollipopActivationDeps,
+  GenericError | NotFoundError,
+  AssertionRef
+> = (fiscalCode) => (deps) =>
+  pipe(
+    deps.SafeRedisClientTask,
+    TE.mapLeft((err) =>
+      toGenericError(`Could not establish connection to redis: ${err.message}`),
+    ),
+    TE.chainW((safeClient) =>
+      pipe(
+        deps.RedisRepository.getLollipopAssertionRefForUser({
+          safeClient,
+          fiscalCode,
+        }),
+        TE.mapLeft((err) =>
+          toGenericError(
+            `Error reading the lollipop assertion ref: [${err.message}]`,
+          ),
+        ),
+      ),
+    ),
+    TE.chainW((maybeAssertionRef) =>
+      pipe(
+        maybeAssertionRef,
+        TE.fromOption(() => toNotFoundError("LollipopActivation")),
+      ),
+    ),
+  );
+
 export type SessionService = typeof SessionService;
 export const SessionService = {
   getUserSession,
@@ -460,4 +500,5 @@ export const SessionService = {
   deleteUserSession,
   invalidateUserSession,
   getUserSessionState,
+  getUserLollipopActivation,
 };

--- a/bruno/io-profile/createProfile.bru
+++ b/bruno/io-profile/createProfile.bru
@@ -1,7 +1,7 @@
 meta {
   name: createProfile
   type: http
-  seq: 1
+  seq: 2
 }
 
 post {

--- a/bruno/io-profile/deleteUserDataProcessing.bru
+++ b/bruno/io-profile/deleteUserDataProcessing.bru
@@ -1,7 +1,7 @@
 meta {
   name: deleteUserDataProcessing
   type: http
-  seq: 11
+  seq: 12
 }
 
 delete {

--- a/bruno/io-profile/getProfile.bru
+++ b/bruno/io-profile/getProfile.bru
@@ -1,7 +1,7 @@
 meta {
   name: getProfile
   type: http
-  seq: 2
+  seq: 3
 }
 
 get {

--- a/bruno/io-profile/getProfileVersions.bru
+++ b/bruno/io-profile/getProfileVersions.bru
@@ -1,7 +1,7 @@
 meta {
   name: getProfileVersions
   type: http
-  seq: 4
+  seq: 5
 }
 
 get {

--- a/bruno/io-profile/getServicePreference.bru
+++ b/bruno/io-profile/getServicePreference.bru
@@ -1,7 +1,7 @@
 meta {
   name: getServicePreference
   type: http
-  seq: 5
+  seq: 6
 }
 
 get {

--- a/bruno/io-profile/getUserDataProcessing.bru
+++ b/bruno/io-profile/getUserDataProcessing.bru
@@ -1,7 +1,7 @@
 meta {
   name: getUserDataProcessing
   type: http
-  seq: 10
+  seq: 11
 }
 
 get {

--- a/bruno/io-profile/info.bru
+++ b/bruno/io-profile/info.bru
@@ -1,19 +1,13 @@
 meta {
-  name: upsertUserDataProcessing
+  name: info
   type: http
-  seq: 10
+  seq: 1
 }
 
-post {
-  url: {{IO_PROFILE_BASE_URL}}/user-data-processing/{{FISCAL_CODE}}
-  body: json
+get {
+  url: {{IO_PROFILE_BASE_URL}}/info
+  body: none
   auth: inherit
-}
-
-body:json {
-  {
-    "choice": "DELETE"
-  }
 }
 
 script:pre-request {

--- a/bruno/io-profile/notifyLogin.bru
+++ b/bruno/io-profile/notifyLogin.bru
@@ -1,7 +1,7 @@
 meta {
   name: notifyLogin
   type: http
-  seq: 8
+  seq: 9
 }
 
 post {

--- a/bruno/io-profile/startEmailValidationProcess.bru
+++ b/bruno/io-profile/startEmailValidationProcess.bru
@@ -1,7 +1,7 @@
 meta {
   name: startEmailValidationProcess
   type: http
-  seq: 7
+  seq: 8
 }
 
 post {

--- a/bruno/io-profile/updateProfile.bru
+++ b/bruno/io-profile/updateProfile.bru
@@ -1,7 +1,7 @@
 meta {
   name: updateProfile
   type: http
-  seq: 3
+  seq: 4
 }
 
 put {

--- a/bruno/io-profile/upsertServicePreference.bru
+++ b/bruno/io-profile/upsertServicePreference.bru
@@ -1,7 +1,7 @@
 meta {
   name: upsertServicePreference
   type: http
-  seq: 6
+  seq: 7
 }
 
 post {

--- a/bruno/io-session-manager-internal/getUserLollipopActivation.bru
+++ b/bruno/io-session-manager-internal/getUserLollipopActivation.bru
@@ -1,0 +1,24 @@
+meta {
+  name: getUserLollipopActivation
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{IO_SM_INT_BASE_URL}}/api/v1/lollipop/{{FISCAL_CODE}}/activation
+  body: none
+  auth: inherit
+}
+
+script:pre-request {
+  // Set header 'x-functions-key' if the necessary key is found in the Environment
+  const ioSmIntApiKey = bru.getEnvVar("IO_SM_INT_API_KEY");
+  if (ioSmIntApiKey != null ) {
+    req.setHeader("x-functions-key", ioSmIntApiKey);
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}


### PR DESCRIPTION
#### List of Changes
- Add new `getUserLollipopActivation` controller in io-profile (apps/io-profile/src/controllers/get-lollipop-activation.ts) and wire it up in apps/io-profile/src/controllers/main.ts.
- Extend `SessionService` with the method used by the new controller (apps/io-profile/src/services/session-service.ts) and add unit tests (apps/io-profile/src/services/__tests__/session-service.test.ts).
- Add controller-level tests (apps/io-profile/src/controllers/__tests__/get-lollipop-activation.test.ts).
- Update the shared session-service mock to cover the new method (apps/io-profile/src/__mocks__/services/session-service.mock.ts).
- Bruno collection:
  - Add `getUserLollipopActivation` request under getUserLollipopActivation.bru.
  - Add `info` endpoint under info.bru.
  - Re-sequence existing `bruno/io-profile/*.bru` requests to accommodate the new entries.

#### Motivation and Context
Expose a dedicated endpoint to retrieve the Lollipop activation status for a given user. This is required for the rollout of the new Session Manager.

Tracking: IOPID-4018.

#### How Has This Been Tested?
- Unit tests for the new controller and for the new `SessionService` method (see the two `__tests__` files listed above), run via the app's Vitest suite.
- Manual verification through the new Bruno request `getUserLollipopActivation.bru` against the local dev environment (docker-compose stack).

#### Types of changes
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [x] My change requires a changeset, which I've added.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. 

