### PR TITLE
[#IOPID-4140] Integrate Platform Internal call into ActivateSession use-case

### DIFF
--- a/.changeset/bright-toes-play.md
+++ b/.changeset/bright-toes-play.md
@@ -1,0 +1,5 @@
+---
+"io-session-manager-oi": minor
+---
+
+Add PlatformInternal Port, integrate into Activate Session use-case

--- a/apps/io-session-manager-oi/openapi-ts.config.ts
+++ b/apps/io-session-manager-oi/openapi-ts.config.ts
@@ -144,4 +144,30 @@ export default defineConfig([
       },
     ],
   },
+  {
+    input:
+      "https://raw.githubusercontent.com/pagopa/io-infra/702da5fed9986814e1e19720b04359d73774b34f/src/common/_modules/platform_api_gateway/api/platform-internal/v1/api.yaml",
+    output: {
+      path: "src/generated/platform-internal",
+      module: {
+        extension: ".js",
+      },
+    },
+    plugins: [
+      "@hey-api/client-fetch",
+      "@hey-api/schemas",
+      "@hey-api/sdk",
+      {
+        name: "zod",
+        $resolvers: {
+          // Intercept all string nodes
+          string: stringResolver,
+        },
+      },
+      {
+        enums: "javascript",
+        name: "@hey-api/typescript",
+      },
+    ],
+  },
 ] as ReadonlyArray<UserConfig>);

--- a/apps/io-session-manager-oi/src/__integrations__/__tests__/activate-user-session.use-case.integration.test.ts
+++ b/apps/io-session-manager-oi/src/__integrations__/__tests__/activate-user-session.use-case.integration.test.ts
@@ -2,7 +2,6 @@ import { CosmosClient } from "@azure/cosmos";
 import { SessionCosmosAdapter } from "@pagopa/io-auth-n-identity-session/adapters";
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { makeActivateUserSessionUseCase } from "../../application/use-cases/activate-user-session.user-case.js";
 import {
   ACTIVE_SESSION_CONTAINER_NAME,
   COSMOSDB_KEY,
@@ -10,6 +9,8 @@ import {
   COSMOSDB_URI,
   IO_PROFILE_API_KEY,
   IO_PROFILE_BASE_URL,
+  PLATFORM_INTERNAL_API_KEY,
+  PLATFORM_INTERNAL_BASE_URL,
   SESSION_TOKEN_CONTAINER_NAME,
 } from "../env.js";
 import {
@@ -21,6 +22,8 @@ import {
   seedSessionCosmosDb,
 } from "../fixtures/sessions.fixture.js";
 import { createIoProfileAdapter } from "../../adapters/outbound/io-profile.adapter.js";
+import { createPlatformInternalAdapter } from "../../adapters/outbound/platform-internal.adapter.js";
+import { makeActivateUserSessionUseCase } from "../../application/use-cases/activate-user-session.use-case.js";
 
 // The number of token documents persisted for a session: the main SESSION-
 // token plus the four SSO tokens (WALLET, BPD, FIMS, ZENDESK).
@@ -45,10 +48,15 @@ const adapter = createIoProfileAdapter({
   baseUrl: IO_PROFILE_BASE_URL,
   apiKey: IO_PROFILE_API_KEY,
 });
+const platformInternalAdapter = createPlatformInternalAdapter({
+  baseUrl: PLATFORM_INTERNAL_BASE_URL,
+  apiKey: PLATFORM_INTERNAL_API_KEY,
+});
 
 const activateUserSession = makeActivateUserSessionUseCase(
   sessionAdapter,
   adapter,
+  platformInternalAdapter,
 );
 
 describe("activate-user-session use case (integration)", () => {
@@ -63,6 +71,7 @@ describe("activate-user-session use case (integration)", () => {
       buildNewSessionTokenInput(NEW_SESSION_FISCAL_CODE),
     );
 
+    console.log("activateUserSession result", result);
     expect(result.isOk()).toBe(true);
 
     const clientSessionToken = result._unsafeUnwrap();

--- a/apps/io-session-manager-oi/src/__integrations__/env.ts
+++ b/apps/io-session-manager-oi/src/__integrations__/env.ts
@@ -2,6 +2,11 @@ export const IO_PROFILE_BASE_URL = `http://localhost:${process.env.FUNCTION_PROF
 
 export const IO_PROFILE_API_KEY = process.env.IO_PROFILE_API_KEY ?? "api_key";
 
+export const PLATFORM_INTERNAL_BASE_URL = `http://localhost:${process.env.FUNCTION_SESSION_MANAGER_INTERNAL_PORT ?? 3009}/api/platform-internal/v1`;
+
+export const PLATFORM_INTERNAL_API_KEY =
+  process.env.PLATFORM_INTERNAL_API_KEY ?? "your-platform-int-api-key";
+
 export const ENVIRONMENT = process.env.ENVIRONMENT || "DEV";
 
 // Cosmos DB (local emulator started via docker-compose).

--- a/apps/io-session-manager-oi/src/__mocks__/ports/platform-internal-port.mock.ts
+++ b/apps/io-session-manager-oi/src/__mocks__/ports/platform-internal-port.mock.ts
@@ -1,0 +1,14 @@
+import { ok } from "neverthrow";
+import { vi } from "vitest";
+
+import { PlatformInternalPort } from "../../domain/ports/outbound/platform-internal.port.js";
+
+export const mockDeletePlatformInternalSession = vi.fn();
+
+export const PlatformInternalPortMock: PlatformInternalPort = {
+  deleteSession: mockDeletePlatformInternalSession,
+};
+
+export const resetPlatformInternalPortMock = () => {
+  mockDeletePlatformInternalSession.mockReset().mockResolvedValue(ok(void 0));
+};

--- a/apps/io-session-manager-oi/src/__mocks__/session.mocks.ts
+++ b/apps/io-session-manager-oi/src/__mocks__/session.mocks.ts
@@ -79,6 +79,11 @@ export const aSessionWithPlainTokens: SessionWithPlainSSOTokens = {
 export const aSessionWithHashedTokens: SessionWithHashedSSOTokens =
   toHashedSession(aSessionWithPlainTokens);
 
+export const aHashedSessionTokenWithSessionId = {
+  sessionId: aSessionId,
+  hashedSessionToken: aSessionWithHashedTokens.hashedSessionToken,
+};
+
 export const aUserProfileWithEmail: UserProfile = {
   fiscalCode: aFiscalCode,
   email: anEmailAddress,

--- a/apps/io-session-manager-oi/src/adapters/outbound/__tests__/platform-internal.adapter.test.ts
+++ b/apps/io-session-manager-oi/src/adapters/outbound/__tests__/platform-internal.adapter.test.ts
@@ -1,0 +1,58 @@
+import { GenericError } from "@pagopa/hexagonal-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createPlatformInternalAdapter } from "../platform-internal.adapter.js";
+import { deleteSession } from "../../../generated/platform-internal/sdk.gen.js";
+import { HashedClientSessionToken } from "../../../domain/value-objects/client-session-token.vo.js";
+
+vi.mock("../../../generated/platform-internal/client/index.js", () => ({
+  createClient: vi.fn(() => ({
+    interceptors: { request: { use: vi.fn() } },
+  })),
+}));
+
+vi.mock("../../../generated/platform-internal/sdk.gen.js", () => ({
+  deleteSession: vi.fn(),
+}));
+
+const SESSION_TOKEN = "a".repeat(64) as HashedClientSessionToken;
+
+const adapter = createPlatformInternalAdapter({
+  baseUrl: "http://localhost",
+  apiKey: "test-key",
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("createPlatformInternalAdapter#deleteSession", () => {
+  it("returns ok(undefined) on 204", async () => {
+    vi.mocked(deleteSession).mockResolvedValue({
+      data: undefined,
+      error: undefined,
+      response: { status: 204 } as Response,
+    });
+
+    const result = await adapter.deleteSession(SESSION_TOKEN);
+
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toBeUndefined();
+  });
+
+  it.each([400, 401, 429, 500])(
+    "returns err(GenericError) on %i",
+    async (status) => {
+      vi.mocked(deleteSession).mockResolvedValue({
+        data: undefined,
+        error: {},
+        response: { status } as Response,
+      });
+
+      const result = await adapter.deleteSession(SESSION_TOKEN);
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(GenericError);
+    },
+  );
+});

--- a/apps/io-session-manager-oi/src/adapters/outbound/__tests__/platform-internal.adapter.test.ts
+++ b/apps/io-session-manager-oi/src/adapters/outbound/__tests__/platform-internal.adapter.test.ts
@@ -15,7 +15,7 @@ vi.mock("../../../generated/platform-internal/sdk.gen.js", () => ({
   deleteSession: vi.fn(),
 }));
 
-const SESSION_TOKEN = "a".repeat(64) as HashedClientSessionToken;
+const SESSION_TOKEN = `aValidSessionId.${"a".repeat(64)}` as HashedClientSessionToken;
 
 const adapter = createPlatformInternalAdapter({
   baseUrl: "http://localhost",

--- a/apps/io-session-manager-oi/src/adapters/outbound/platform-internal.adapter.ts
+++ b/apps/io-session-manager-oi/src/adapters/outbound/platform-internal.adapter.ts
@@ -1,0 +1,65 @@
+import { GenericError } from "@pagopa/hexagonal-core";
+import { err, ok } from "neverthrow";
+
+import type { PlatformInternalPort } from "../../domain/ports/outbound/platform-internal.port.js";
+import { createClient } from "../../generated/platform-internal/client/index.js";
+import { deleteSession } from "../../generated/platform-internal/sdk.gen.js";
+import type {
+  DeleteSessionErrors,
+  DeleteSessionResponses,
+} from "../../generated/platform-internal/types.gen.js";
+
+export const createPlatformInternalAdapter = (config: {
+  baseUrl: string;
+  apiKey: string;
+}): PlatformInternalPort => {
+  const client = createClient({
+    baseUrl: config.baseUrl,
+    headers: {
+      "X-Functions-Key": config.apiKey,
+    },
+  });
+
+  return {
+    deleteSession: async (sessionToken) => {
+      const { response } = await deleteSession({
+        client,
+        headers: {
+          "X-Session-Token": sessionToken,
+        },
+      });
+
+      const status = response?.status as
+        | keyof DeleteSessionResponses
+        | keyof DeleteSessionErrors;
+
+      switch (status) {
+        case 204:
+          return ok(void 0);
+        case 400:
+          return err(new GenericError("Invalid request to platform-internal"));
+        case 401:
+          return err(
+            new GenericError("Unauthorized request to platform-internal"),
+          );
+        case 429:
+          return err(
+            new GenericError("Too many requests to platform-internal"),
+          );
+        case 500:
+          return err(
+            new GenericError("Internal server error from platform-internal"),
+          );
+        default: {
+          // exhaustive check for all possible status codes
+          const _exhaustiveCheck: never = status;
+          return err(
+            new GenericError(
+              `Unexpected error from platform-internal: ${status}`,
+            ),
+          );
+        }
+      }
+    },
+  };
+};

--- a/apps/io-session-manager-oi/src/application/use-cases/__tests__/activate-user-session.use-case.test.ts
+++ b/apps/io-session-manager-oi/src/application/use-cases/__tests__/activate-user-session.use-case.test.ts
@@ -18,11 +18,17 @@ import {
   SessionPortMock,
 } from "../../../__mocks__/ports/session-port.mock.js";
 import {
+  mockDeletePlatformInternalSession,
+  PlatformInternalPortMock,
+  resetPlatformInternalPortMock,
+} from "../../../__mocks__/ports/platform-internal-port.mock.js";
+import {
   aClientSessionToken,
   anEmailAddress,
   aFamilyName,
   aFiscalCode,
   aGenericError,
+  aHashedSessionTokenWithSessionId,
   aName,
   aNewSessionTokenInput,
   aNewSessionTokenInputWithoutSpidEmail,
@@ -62,12 +68,14 @@ vi.mock("@pagopa/io-auth-n-identity-session/entities", async (importActual) => {
 const activateUserSession = makeActivateUserSessionUseCase(
   SessionPortMock,
   ProfilePortMock,
+  PlatformInternalPortMock,
 );
 
 beforeEach(() => {
   vi.clearAllMocks();
   resetSessionPortMock();
   resetProfilePortMock();
+  resetPlatformInternalPortMock();
   vi.mocked(newSessionId).mockResolvedValue(aSessionId);
   vi.mocked(newPlainSession).mockResolvedValue(aSessionWithPlainTokens);
 });
@@ -232,6 +240,49 @@ describe("makeActivateUserSessionUseCase", () => {
           ),
         ),
       );
+    });
+
+    it("returns err when proxy deleteSession fails", async () => {
+      mockInvalidatePreviousSession.mockResolvedValueOnce(
+        ok(aHashedSessionTokenWithSessionId),
+      );
+      mockDeletePlatformInternalSession.mockResolvedValueOnce(
+        err(aGenericError),
+      );
+
+      const result = await activateUserSession(aNewSessionTokenInput);
+
+      expect(result).toMatchObject(
+        err(
+          new GenericError(
+            `Failed to invalidate previous session on proxy: ${aGenericError.message}`,
+          ),
+        ),
+      );
+      expect(mockSessionCreate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("proxy deleteSession", () => {
+    it("calls deleteSession with the hashed session token when a previous session exists", async () => {
+      mockInvalidatePreviousSession.mockResolvedValueOnce(
+        ok(aHashedSessionTokenWithSessionId),
+      );
+
+      const result = await activateUserSession(aNewSessionTokenInput);
+
+      expect(result).toMatchObject(ok(aClientSessionToken));
+      expect(mockDeletePlatformInternalSession).toHaveBeenCalledExactlyOnceWith(
+        `${aHashedSessionTokenWithSessionId.sessionId}.${aHashedSessionTokenWithSessionId.hashedSessionToken}`,
+      );
+    });
+
+    it("skips deleteSession when there is no previous session", async () => {
+      // mockInvalidatePreviousSession default returns ok(undefined)
+      const result = await activateUserSession(aNewSessionTokenInput);
+
+      expect(result).toMatchObject(ok(aClientSessionToken));
+      expect(mockDeletePlatformInternalSession).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/io-session-manager-oi/src/application/use-cases/activate-user-session.use-case.ts
+++ b/apps/io-session-manager-oi/src/application/use-cases/activate-user-session.use-case.ts
@@ -86,11 +86,22 @@ export const makeActivateUserSessionUseCase =
     }
 
     if (invalidateResult.value !== undefined) {
-      const hashedClientSessionToken = HashedClientSessionTokenSchema.parse(
-        `${invalidateResult.value.sessionId}.${invalidateResult.value.hashedSessionToken}`,
-      );
+      const hashedClientSessionTokenResult =
+        HashedClientSessionTokenSchema.safeParse(
+          `${invalidateResult.value.sessionId}.${invalidateResult.value.hashedSessionToken}`,
+        );
+
+      // This should never happen, but we check it just in case, to avoid sending an invalid token to the platform-internal service.
+      if (!hashedClientSessionTokenResult.success) {
+        return err(
+          new GenericError(
+            `Failed to parse hashed client session token: ${hashedClientSessionTokenResult.error.message}`,
+          ),
+        );
+      }
+
       const proxyResult = await platformInternal.deleteSession(
-        hashedClientSessionToken,
+        hashedClientSessionTokenResult.data,
       );
 
       if (proxyResult.isErr()) {

--- a/apps/io-session-manager-oi/src/application/use-cases/activate-user-session.use-case.ts
+++ b/apps/io-session-manager-oi/src/application/use-cases/activate-user-session.use-case.ts
@@ -24,7 +24,9 @@ import { UserProfile } from "../../domain/entities/profile.entity.js";
 import {
   ClientSessionToken,
   ClientSessionTokenSchema,
+  HashedClientSessionTokenSchema,
 } from "../../domain/value-objects/client-session-token.vo.js";
+import { PlatformInternalPort } from "../../domain/ports/outbound/platform-internal.port.js";
 
 export type NewSessionToken = Omit<
   BaseSession,
@@ -49,6 +51,7 @@ export const makeActivateUserSessionUseCase =
   (
     userSessions: SessionPort,
     profiles: ProfilePort,
+    platformInternal: PlatformInternalPort,
   ): ActivateUserSessionUseCase =>
   async (input) => {
     // TODO: check if we can move newSessionId() within newActiveSession() to avoid having to pass sessionId as a parameter
@@ -82,6 +85,23 @@ export const makeActivateUserSessionUseCase =
       );
     }
 
+    if (invalidateResult.value !== undefined) {
+      const hashedClientSessionToken = HashedClientSessionTokenSchema.parse(
+        `${invalidateResult.value.sessionId}.${invalidateResult.value.hashedSessionToken}`,
+      );
+      const proxyResult = await platformInternal.deleteSession(
+        hashedClientSessionToken,
+      );
+
+      if (proxyResult.isErr()) {
+        return err(
+          new GenericError(
+            `Failed to invalidate previous session on proxy: ${proxyResult.error.message}`,
+          ),
+        );
+      }
+    }
+
     // Retrieve user profile, if exists, or create a new one with the provided data.
     // This is needed to ensure that the user profile exists before creating a new session.
     const getOrCreateProfileResult = await getOrCreateProfile(profiles, input);
@@ -91,8 +111,6 @@ export const makeActivateUserSessionUseCase =
     }
 
     const userProfile = getOrCreateProfileResult.value;
-
-    // TODO: call proxy to invalidate previous sessions with invalidatePreviousSession (if any)
 
     const result = await userSessions.create(
       activeSession,

--- a/apps/io-session-manager-oi/src/domain/ports/outbound/platform-internal.port.ts
+++ b/apps/io-session-manager-oi/src/domain/ports/outbound/platform-internal.port.ts
@@ -4,6 +4,6 @@ import { HashedClientSessionToken } from "../../value-objects/client-session-tok
 
 export interface PlatformInternalPort {
   deleteSession(
-    hashedSessionToken: HashedClientSessionToken,
+    hashedClientSessionToken: HashedClientSessionToken,
   ): Promise<Result<void, GenericError>>;
 }

--- a/apps/io-session-manager-oi/src/domain/ports/outbound/platform-internal.port.ts
+++ b/apps/io-session-manager-oi/src/domain/ports/outbound/platform-internal.port.ts
@@ -1,0 +1,9 @@
+import { type GenericError } from "@pagopa/hexagonal-core";
+import { type Result } from "neverthrow";
+import { HashedClientSessionToken } from "../../value-objects/client-session-token.vo.js";
+
+export interface PlatformInternalPort {
+  deleteSession(
+    hashedSessionToken: HashedClientSessionToken,
+  ): Promise<Result<void, GenericError>>;
+}

--- a/apps/io-session-manager-oi/src/domain/value-objects/client-session-token.vo.ts
+++ b/apps/io-session-manager-oi/src/domain/value-objects/client-session-token.vo.ts
@@ -1,6 +1,7 @@
 import z from "zod";
 
 import {
+  HashedSessionTokenSchema,
   PlainSessionTokenSchema,
   SessionIdSchema,
 } from "@pagopa/io-auth-n-identity-session/value-objects";
@@ -10,3 +11,11 @@ export const ClientSessionTokenSchema = z
   .brand<"ClientSessionToken">();
 
 export type ClientSessionToken = z.infer<typeof ClientSessionTokenSchema>;
+
+export const HashedClientSessionTokenSchema = z
+  .templateLiteral([SessionIdSchema, ".", HashedSessionTokenSchema])
+  .brand<"HashedClientSessionToken">();
+
+export type HashedClientSessionToken = z.infer<
+  typeof HashedClientSessionTokenSchema
+>;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR depends on #778 

#### List of Changes
<!--- Describe your changes in detail -->

- Added `HashedClientSessionToken` value object/schema and a new `PlatformInternalPort` outbound interface.
- Updated `makeActivateUserSessionUseCase` to call `platformInternal.deleteSession(...)` when a previous session exists.
- Added platform-internal outbound adapter + unit tests, updated use-case tests, and added OpenAPI codegen config plus a changeset.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This PR extends the `io-session-manager-oi` “ActivateUserSession” flow by introducing an outbound `PlatformInternalPort` and calling platform-internal to delete/invalidate the previous session when `invalidatePreviousSession` returns a prior hashed token.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a changeset, which I've added.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
